### PR TITLE
fix: correct Pdf1040 2025 field mapping and route Sch D/E outputs

### DIFF
--- a/tenforty/mappings/pdf_1040.py
+++ b/tenforty/mappings/pdf_1040.py
@@ -50,37 +50,36 @@ class Pdf1040:
             # Line 1z: Total of 1a through 1i
             "total_w2_income": "topmostSubform[0].Page1[0].f1_56[0]",
             # Line 2a: Tax-exempt interest
-            "tax_exempt_interest": "topmostSubform[0].Page1[0].f1_57[0]",
+            "tax_exempt_interest": "topmostSubform[0].Page1[0].f1_58[0]",
             # Line 2b: Taxable interest
-            "taxable_interest": "topmostSubform[0].Page1[0].f1_58[0]",
+            "taxable_interest": "topmostSubform[0].Page1[0].f1_59[0]",
             # Line 3a: Qualified dividends
-            "qualified_dividends": "topmostSubform[0].Page1[0].f1_59[0]",
+            "qualified_dividends": "topmostSubform[0].Page1[0].f1_60[0]",
             # Line 3b: Ordinary dividends
-            "ordinary_dividends": "topmostSubform[0].Page1[0].f1_60[0]",
+            "ordinary_dividends": "topmostSubform[0].Page1[0].f1_61[0]",
             # Line 4a: IRA distributions
-            "ira_distributions": "topmostSubform[0].Page1[0].f1_61[0]",
+            "ira_distributions": "topmostSubform[0].Page1[0].f1_62[0]",
             # Line 4b: IRA taxable amount
-            "ira_taxable": "topmostSubform[0].Page1[0].f1_62[0]",
+            "ira_taxable": "topmostSubform[0].Page1[0].f1_63[0]",
             # Line 5a: Pensions and annuities
-            "pensions": "topmostSubform[0].Page1[0].f1_63[0]",
+            "pensions": "topmostSubform[0].Page1[0].f1_65[0]",
             # Line 5b: Pensions taxable amount
-            "pensions_taxable": "topmostSubform[0].Page1[0].f1_64[0]",
+            "pensions_taxable": "topmostSubform[0].Page1[0].f1_66[0]",
             # Line 6a: Social security benefits
-            "social_security": "topmostSubform[0].Page1[0].f1_65[0]",
+            "social_security": "topmostSubform[0].Page1[0].f1_68[0]",
             # Line 6b: Social security taxable amount
-            "social_security_taxable": "topmostSubform[0].Page1[0].f1_66[0]",
-            # Line 6c: Lump-sum election
-            "lump_sum_election": "topmostSubform[0].Page1[0].f1_67[0]",
-            # Line 7: Capital gain or (loss)
-            "capital_gain_loss": "topmostSubform[0].Page1[0].f1_68[0]",
+            "social_security_taxable": "topmostSubform[0].Page1[0].f1_69[0]",
+            # Line 7a: Capital gain or (loss)
+            "capital_gain_loss": "topmostSubform[0].Page1[0].f1_70[0]",
+            # Line 7b: (new on 2025 form — unmapped, reserved for future use)
             # Line 8: Other income from Schedule 1, line 10
-            "other_income": "topmostSubform[0].Page1[0].f1_69[0]",
+            "other_income": "topmostSubform[0].Page1[0].f1_72[0]",
             # Line 9: Total income
-            "total_income": "topmostSubform[0].Page1[0].f1_70[0]",
+            "total_income": "topmostSubform[0].Page1[0].f1_73[0]",
             # Line 10: Adjustments to income from Schedule 1, line 26
-            "adjustments": "topmostSubform[0].Page1[0].f1_71[0]",
-            # Line 11: Adjusted gross income
-            "agi": "topmostSubform[0].Page1[0].f1_72[0]",
+            "adjustments": "topmostSubform[0].Page1[0].f1_74[0]",
+            # Line 11a: Adjusted gross income
+            "agi": "topmostSubform[0].Page1[0].f1_75[0]",
 
             # === Page 2: Tax and Credits (Lines 11b-24) ===
             # Line 11b (AGI repeated at top of page 2)

--- a/tenforty/mappings/pdf_1040.py
+++ b/tenforty/mappings/pdf_1040.py
@@ -43,12 +43,13 @@ class Pdf1040:
             "adoption_benefits": "topmostSubform[0].Page1[0].f1_52[0]",
             # Line 1g: Form 8919 wages
             "form_8919_wages": "topmostSubform[0].Page1[0].f1_53[0]",
-            # Line 1h: Strike benefits
-            "strike_benefits": "topmostSubform[0].Page1[0].f1_54[0]",
-            # Line 1i: Stock option income
-            "stock_option_income": "topmostSubform[0].Page1[0].f1_55[0]",
-            # Line 1z: Total of 1a through 1i
-            "total_w2_income": "topmostSubform[0].Page1[0].f1_56[0]",
+            # Line 1h: Other earned income — type (f1_54) and amount (f1_55)
+            "other_earned_income_type": "topmostSubform[0].Page1[0].f1_54[0]",
+            "other_earned_income": "topmostSubform[0].Page1[0].f1_55[0]",
+            # Line 1i: Nontaxable combat pay election
+            "combat_pay_election": "topmostSubform[0].Page1[0].f1_56[0]",
+            # Line 1z: Total of 1a through 1h
+            "total_w2_income": "topmostSubform[0].Page1[0].f1_57[0]",
             # Line 2a: Tax-exempt interest
             "tax_exempt_interest": "topmostSubform[0].Page1[0].f1_58[0]",
             # Line 2b: Taxable interest
@@ -94,57 +95,57 @@ class Pdf1040:
             "total_deductions": "topmostSubform[0].Page2[0].f2_05[0]",
             # Line 15: Taxable income (line 11b minus line 14)
             "taxable_income": "topmostSubform[0].Page2[0].f2_06[0]",
-            # Line 16: Tax (from tax table or QDCG worksheet)
-            "total_tax": "topmostSubform[0].Page2[0].f2_07[0]",
+            # Line 16: Tax (f2_07 is the 8814/4972 checkbox value on this line)
+            "total_tax": "topmostSubform[0].Page2[0].f2_08[0]",
             # Line 17: Amount from Schedule 2, line 3
-            "schedule2_tax": "topmostSubform[0].Page2[0].f2_08[0]",
+            "schedule2_tax": "topmostSubform[0].Page2[0].f2_09[0]",
             # Line 18: Add lines 16 and 17
-            "tax_plus_schedule2": "topmostSubform[0].Page2[0].f2_09[0]",
+            "tax_plus_schedule2": "topmostSubform[0].Page2[0].f2_10[0]",
             # Line 19: Child tax credit / credit for other dependents
-            "child_tax_credit": "topmostSubform[0].Page2[0].f2_10[0]",
+            "child_tax_credit": "topmostSubform[0].Page2[0].f2_11[0]",
             # Line 20: Amount from Schedule 3, line 8
-            "schedule3_credits": "topmostSubform[0].Page2[0].f2_11[0]",
+            "schedule3_credits": "topmostSubform[0].Page2[0].f2_12[0]",
             # Line 21: Add lines 19 and 20
-            "total_credits": "topmostSubform[0].Page2[0].f2_12[0]",
+            "total_credits": "topmostSubform[0].Page2[0].f2_13[0]",
             # Line 22: Subtract line 21 from line 18
-            "tax_after_credits": "topmostSubform[0].Page2[0].f2_13[0]",
+            "tax_after_credits": "topmostSubform[0].Page2[0].f2_14[0]",
             # Line 23: Other taxes from Schedule 2, line 21
-            "other_taxes": "topmostSubform[0].Page2[0].f2_14[0]",
+            "other_taxes": "topmostSubform[0].Page2[0].f2_15[0]",
             # Line 24: Total tax (add lines 22 and 23)
-            "total_tax_liability": "topmostSubform[0].Page2[0].f2_15[0]",
+            "total_tax_liability": "topmostSubform[0].Page2[0].f2_16[0]",
 
             # === Page 2: Payments (Lines 25-33) ===
             # Line 25a: Federal income tax withheld from W-2
-            "federal_withheld_w2": "topmostSubform[0].Page2[0].f2_16[0]",
+            "federal_withheld_w2": "topmostSubform[0].Page2[0].f2_17[0]",
             # Line 25b: Federal income tax withheld from 1099
-            "federal_withheld_1099": "topmostSubform[0].Page2[0].f2_17[0]",
+            "federal_withheld_1099": "topmostSubform[0].Page2[0].f2_18[0]",
             # Line 25c: Other forms (see instructions)
-            "federal_withheld_other": "topmostSubform[0].Page2[0].f2_18[0]",
+            "federal_withheld_other": "topmostSubform[0].Page2[0].f2_19[0]",
             # Line 25d: Total (add 25a through 25c)
-            "federal_withheld": "topmostSubform[0].Page2[0].f2_19[0]",
+            "federal_withheld": "topmostSubform[0].Page2[0].f2_20[0]",
             # Line 26: Estimated tax payments
-            "estimated_payments": "topmostSubform[0].Page2[0].f2_20[0]",
+            "estimated_payments": "topmostSubform[0].Page2[0].f2_21[0]",
+            # f2_22 is the EIC-spouse-SSN field
             # Line 27a: Earned income credit (EIC)
-            "eic": "topmostSubform[0].Page2[0].f2_21[0]",
-            # f2_22 is the EIC SSN field (in SSN_ReadOrder group)
+            "eic": "topmostSubform[0].Page2[0].f2_23[0]",
             # Line 28: Additional child tax credit from Schedule 8812
-            "additional_child_tax_credit": "topmostSubform[0].Page2[0].f2_23[0]",
+            "additional_child_tax_credit": "topmostSubform[0].Page2[0].f2_24[0]",
             # Line 29: American opportunity credit from Form 8863
-            "american_opportunity_credit": "topmostSubform[0].Page2[0].f2_24[0]",
+            "american_opportunity_credit": "topmostSubform[0].Page2[0].f2_25[0]",
             # Line 30: Refundable adoption credit from Form 8839
-            "adoption_credit_8839": "topmostSubform[0].Page2[0].f2_25[0]",
+            "adoption_credit_8839": "topmostSubform[0].Page2[0].f2_26[0]",
             # Line 31: Amount from Schedule 3, line 15
-            "schedule3_payments": "topmostSubform[0].Page2[0].f2_26[0]",
+            "schedule3_payments": "topmostSubform[0].Page2[0].f2_27[0]",
             # Line 32: Total other payments and refundable credits
-            "total_other_payments": "topmostSubform[0].Page2[0].f2_27[0]",
+            "total_other_payments": "topmostSubform[0].Page2[0].f2_28[0]",
             # Line 33: Total payments (add lines 25d, 26, and 32)
-            "total_payments": "topmostSubform[0].Page2[0].f2_28[0]",
+            "total_payments": "topmostSubform[0].Page2[0].f2_29[0]",
 
             # === Page 2: Refund / Amount You Owe (Lines 34-38) ===
             # Line 34: Overpaid (if line 33 > line 24)
-            "overpaid": "topmostSubform[0].Page2[0].f2_29[0]",
+            "overpaid": "topmostSubform[0].Page2[0].f2_30[0]",
             # Line 35a: Amount of line 34 you want refunded to you
-            "refund": "topmostSubform[0].Page2[0].f2_30[0]",
+            "refund": "topmostSubform[0].Page2[0].f2_31[0]",
             # f2_31 is "If Form 8888 is attached, check here"
             # f2_32 is routing number, f2_33 is account number
             # Line 36: Applied to next year estimated tax

--- a/tenforty/mappings/pdf_1040.py
+++ b/tenforty/mappings/pdf_1040.py
@@ -66,13 +66,16 @@ class Pdf1040:
             "pensions": "topmostSubform[0].Page1[0].f1_65[0]",
             # Line 5b: Pensions taxable amount
             "pensions_taxable": "topmostSubform[0].Page1[0].f1_66[0]",
+            # Line 5c: "Other" explanation (for the 3rd checkbox; 1=rollover, 2=PSO, 3=other)
+            "pensions_other_explanation": "topmostSubform[0].Page1[0].f1_67[0]",
             # Line 6a: Social security benefits
             "social_security": "topmostSubform[0].Page1[0].f1_68[0]",
             # Line 6b: Social security taxable amount
             "social_security_taxable": "topmostSubform[0].Page1[0].f1_69[0]",
             # Line 7a: Capital gain or (loss)
             "capital_gain_loss": "topmostSubform[0].Page1[0].f1_70[0]",
-            # Line 7b: (new on 2025 form — unmapped, reserved for future use)
+            # Line 7b: Amount for the "includes child's capital gain or (loss)" checkbox
+            "child_capital_gain": "topmostSubform[0].Page1[0].f1_71[0]",
             # Line 8: Other income from Schedule 1, line 10
             "other_income": "topmostSubform[0].Page1[0].f1_72[0]",
             # Line 9: Total income

--- a/tenforty/translations/f1040_pdf.py
+++ b/tenforty/translations/f1040_pdf.py
@@ -10,6 +10,14 @@ F1040_PDF_SPEC = TranslationSpec(
     renames={
         "interest_income": "taxable_interest",
         "dividend_income": "ordinary_dividends",
+        # Sch D line 16 = 1040 line 7 (capital gain or loss).
+        "schd_line16": "capital_gain_loss",
+        # Sch E line 26 flows via Sch 1 line 5 to Sch 1 line 10 to 1040 line 8.
+        # Engine does not yet aggregate Schedule 1 line 10 — this rename works
+        # for scenarios where Sch E is the only Sch 1 contributor. When other
+        # Sch 1 income appears (unemployment, business, etc.) the engine must
+        # grow a dedicated schedule_1_line_10 output.
+        "sche_line26": "other_income",
     },
     expansions={
         "agi": ["agi", "agi_page2"],

--- a/tests/test_f1040_translation.py
+++ b/tests/test_f1040_translation.py
@@ -49,11 +49,20 @@ class TestF1040PdfTranslation(unittest.TestCase):
         self.assertEqual(result["taxable_income"], 84250)
         self.assertEqual(result["overpaid"], 1500)
 
-    def test_schedule_subtotals_passed_through(self):
-        """Schedule subtotals pass through but won't match any PDF field."""
+    def test_schd_line16_renamed_to_capital_gain(self):
+        """Sch D line 16 routes to 1040 line 7 (capital_gain_loss)."""
         translator = ResultTranslator(F1040_PDF_SPEC)
         result = translator.translate(
-            {"sche_line26": 5000, "schd_line16": 3000, "wages": 100000},
-            make_simple_scenario(),
+            {"schd_line16": 4992}, make_simple_scenario(),
         )
-        self.assertEqual(result["wages"], 100000)
+        self.assertEqual(result["capital_gain_loss"], 4992)
+        self.assertNotIn("schd_line16", result)
+
+    def test_sche_line26_renamed_to_other_income(self):
+        """Sch E line 26 routes to 1040 line 8 (other_income)."""
+        translator = ResultTranslator(F1040_PDF_SPEC)
+        result = translator.translate(
+            {"sche_line26": 3899}, make_simple_scenario(),
+        )
+        self.assertEqual(result["other_income"], 3899)
+        self.assertNotIn("sche_line26", result)

--- a/tests/test_pdf_1040_fill.py
+++ b/tests/test_pdf_1040_fill.py
@@ -118,8 +118,44 @@ class TestPdf1040FillGroundTruth(unittest.TestCase):
         self._assert_field("topmostSubform[0].Page1[0].f1_70[0]", "")
 
     # === PAGE 2 ===
+    # Page 2 lines 16-35a were off-by-one (16-26) and off-by-two (27a-35a)
+    # relative to the current form revision. These assertions pin them.
+    def test_line_11b_agi_copy(self):
+        self._assert_field("topmostSubform[0].Page2[0].f2_01[0]", "12750")
+
+    def test_line_12e_standard_deduction(self):
+        self._assert_field("topmostSubform[0].Page2[0].f2_02[0]", "15750")
+
+    def test_line_14_total_deductions(self):
+        self._assert_field("topmostSubform[0].Page2[0].f2_05[0]", "15750")
+
+    def test_line_15_taxable_income(self):
+        # 12750 - 15750 < 0 -> 0
+        self._assert_field("topmostSubform[0].Page2[0].f2_06[0]", "0")
+
+    def test_line_16_total_tax(self):
+        # Regression guard: f2_07 is the 8814/4972 checkbox on line 16,
+        # NOT the amount. Line 16 amount is f2_08. Tax on 0 taxable = 0.
+        self._assert_field("topmostSubform[0].Page2[0].f2_08[0]", "0")
+
+    def test_line_24_total_tax_liability_blank(self):
+        # Engine doesn't produce `total_tax_liability` for this scenario
+        # (total tax = 0). Field must stay blank — regression guard against
+        # e.g. `overpaid` (2034) accidentally routing here.
+        self._assert_field("topmostSubform[0].Page2[0].f2_16[0]", "")
+
     def test_line_25a_federal_withheld_w2(self):
-        self._assert_field("topmostSubform[0].Page2[0].f2_16[0]", "1550")
+        self._assert_field("topmostSubform[0].Page2[0].f2_17[0]", "1550")
+
+    def test_line_25d_federal_withheld_total(self):
+        self._assert_field("topmostSubform[0].Page2[0].f2_20[0]", "1550")
+
+    def test_line_33_total_payments(self):
+        # 1550 W-2 withholding + 484 EIC (single, $12,350 AGI, no kids).
+        self._assert_field("topmostSubform[0].Page2[0].f2_29[0]", "2034")
+
+    def test_line_34_overpaid(self):
+        self._assert_field("topmostSubform[0].Page2[0].f2_30[0]", "2034")
 
 
 if __name__ == "__main__":

--- a/tests/test_pdf_1040_fill.py
+++ b/tests/test_pdf_1040_fill.py
@@ -1,0 +1,126 @@
+"""Fill-and-reread integration test for the 2025 Form 1040 PDF mapping.
+
+Ground truth (field name -> form line) was transcribed from the probe rendered
+by scripts/probe_pdf_fields.py. The 2025 form shifted field numbers relative
+to the mapping that was originally committed. Update these assertions whenever
+the IRS re-issues the form and field numbers shift again.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pypdf
+
+from tenforty.models import (
+    FilingStatus,
+    Form1099DIV,
+    Form1099INT,
+    Scenario,
+    TaxReturnConfig,
+    W2,
+)
+from tenforty.orchestrator import ReturnOrchestrator
+
+REPO_ROOT = Path(__file__).parent.parent
+F1040_TEMPLATE = REPO_ROOT / "pdfs" / "federal" / "2025" / "f1040.pdf"
+
+
+def _build_synthetic_scenario() -> Scenario:
+    return Scenario(
+        config=TaxReturnConfig(
+            year=2025,
+            filing_status=FilingStatus.SINGLE,
+            birthdate="1980-01-01",
+            state="CA",
+            first_name="Alice",
+            last_name="Example",
+            ssn="000-00-0001",
+            address="1 Test Street",
+            address_city="Testville",
+            address_state="TX",
+            address_zip="00001",
+        ),
+        w2s=[
+            W2(
+                employer="Tech Corp",
+                wages=12350.00,
+                federal_tax_withheld=1550.00,
+                ss_wages=12350.00,
+                ss_tax_withheld=750.00,
+                medicare_wages=12350.00,
+                medicare_tax_withheld=200.00,
+            )
+        ],
+        form1099_int=[Form1099INT(payer="National Bank", interest=150.00)],
+        form1099_div=[
+            Form1099DIV(
+                payer="Investment Brokerage",
+                ordinary_dividends=250.00,
+                qualified_dividends=200.00,
+            )
+        ],
+    )
+
+
+@unittest.skipUnless(F1040_TEMPLATE.exists(), "f1040.pdf template not found")
+class TestPdf1040FillGroundTruth(unittest.TestCase):
+    """Pin field-name -> value routing against the 2025 form revision."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmpdir = tempfile.mkdtemp()
+        out_dir = Path(cls._tmpdir)
+        scenario = _build_synthetic_scenario()
+        orch = ReturnOrchestrator(
+            spreadsheets_dir=REPO_ROOT / "spreadsheets",
+            work_dir=out_dir / "work",
+        )
+        cls.results = orch.compute_federal(scenario)
+        emitted = orch.emit_pdfs(scenario, cls.results, out_dir)
+        reader = pypdf.PdfReader(str(emitted["1040"]))
+        fields = reader.get_fields() or {}
+        cls.field_values = {
+            name: (field.get("/V") or "") for name, field in fields.items()
+        }
+
+    def _assert_field(self, field_name: str, expected: str):
+        actual = self.field_values.get(field_name, "<missing>")
+        self.assertEqual(
+            actual, expected,
+            f"Field {field_name} expected {expected!r} got {actual!r}",
+        )
+
+    # === PAGE 1 ===
+    def test_line_1a_wages(self):
+        self._assert_field("topmostSubform[0].Page1[0].f1_47[0]", "12350")
+
+    def test_line_2b_taxable_interest(self):
+        # Translation: engine `interest_income` -> `taxable_interest`.
+        self._assert_field("topmostSubform[0].Page1[0].f1_59[0]", "150")
+
+    def test_line_3b_ordinary_dividends(self):
+        # Translation: engine `dividend_income` -> `ordinary_dividends`.
+        self._assert_field("topmostSubform[0].Page1[0].f1_61[0]", "250")
+
+    def test_line_9_total_income(self):
+        self._assert_field("topmostSubform[0].Page1[0].f1_73[0]", "12750")
+
+    def test_line_11a_agi(self):
+        self._assert_field("topmostSubform[0].Page1[0].f1_75[0]", "12750")
+
+    def test_line_7a_capital_gain_left_blank(self):
+        # Engine produces no `capital_gain_loss` key for this W-2 scenario;
+        # Schedule D line 16 is surfaced as `schd_line16` but no translation
+        # rename wires it. Field f1_70 must stay blank — regression guard
+        # against accidental routing of total_income here, which is the bug
+        # that motivated this fix.
+        self._assert_field("topmostSubform[0].Page1[0].f1_70[0]", "")
+
+    # === PAGE 2 ===
+    def test_line_25a_federal_withheld_w2(self):
+        self._assert_field("topmostSubform[0].Page2[0].f2_16[0]", "1550")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Rebuild the 2025 Pdf1040 field mapping against ground-truth labels Juno wrote into the template. The 2025 form added a checkbox (f2_07) on line 16 and re-used f2_22 for the EIC spouse SSN, shifting every amount field on page 2 by +1 for lines 16–26 and by +2 for lines 27a–35a. Line 1h was also relabeled from the old strike-benefits/stock-option split to a generic "other earned income" type+amount pair, with a new line 1i combat-pay-election slot.
- Map two previously unmapped 2025 fields: line 5c "other" explanation (f1_67) and line 7b child capital gain amount (f1_71).
- Fix two translator gaps so engine outputs actually reach the PDF: `schd_line16` → `capital_gain_loss` (1040 line 7) and `sche_line26` → `other_income` (1040 line 8). The Sch E rename is correct only while Schedule E is the sole Schedule 1 contributor; once the engine aggregates Sch 1 line 10, swap to that.

Verified against Juno's real scenario: lines 7 and 8 now populate correctly, AGI renders correctly on lines 11a/11b, and page 2 amount fields align with their printed labels.

Closes translunar/tenforty#7

## Test plan

- [x] `pytest tests/test_pdf_1040_fill.py` — 16/16 pin field-name → value routing against 2025 form revision
- [x] `pytest tests/test_f1040_translation.py` — Sch D and Sch E rename assertions pass
- [x] `pytest tests/test_result_translator.py` — translator invariants hold
- [ ] Follow-up: wire `F8959_WH` (Additional Medicare Tax withholding) into the engine and route to 25c; compute 25d as 25a+25b+25c

🤖 Generated with [Claude Code](https://claude.com/claude-code)