### PR TITLE
fix: use sys.executable in test_no_personal_data subprocess

### DIFF
--- a/tests/test_no_personal_data.py
+++ b/tests/test_no_personal_data.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import unittest
 
 from tests.helpers import REPO_ROOT
@@ -8,7 +9,7 @@ class TestNoPersonalData(unittest.TestCase):
     def test_verification_script_passes(self):
         """Run the personal data verification script and assert it exits cleanly."""
         result = subprocess.run(
-            ["python", str(REPO_ROOT / "scripts" / "verify_no_personal_data.py")],
+            [sys.executable, str(REPO_ROOT / "scripts" / "verify_no_personal_data.py")],
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),


### PR DESCRIPTION
## Summary
- `test_verification_script_passes` shelled out with bare \`python\`, which isn't in PATH when pytest runs under a \`.venv\` whose interpreter is \`python3.14\`. The test was failing with \`FileNotFoundError: [Errno 2] No such file or directory: 'python'\` regardless of the verification script's own output.
- Switched to \`sys.executable\` so the subprocess always uses the same interpreter as the test runner.

## Test plan
- [x] \`.venv/bin/pytest tests/test_no_personal_data.py -v\` → passes