### PR TITLE
Pass 1: Post-Plan D cleanup — 12 /simplify findings

### DIFF
--- a/tenforty/attestations.py
+++ b/tenforty/attestations.py
@@ -7,7 +7,7 @@ contract:
   `compute_error` at compute time.
 - `True` → proceed (the scope-out path is accepted by the user).
 
-Single source of truth for the 13 Plan B + Plan D attestations. Both
+Single source of truth for all 13 attestations. Both
 scenario._validate_scenario_config and sch_e_part_ii._enforce_scope_gates
 iterate this tuple rather than hand-coded `if ... is None: raise` blocks.
 
@@ -89,7 +89,7 @@ def _never(s: Scenario) -> bool:
 
 
 _ATTESTATIONS: tuple[Attestation, ...] = (
-    # --- Load-time-only (Plan B) attestations ---
+    # --- Load-time-only attestations ---
     Attestation(
         field="has_foreign_accounts",
         triggered_when=_never,  # True-branch raises at load; see scenario._validate_scenario_config.
@@ -153,9 +153,9 @@ _ATTESTATIONS: tuple[Attestation, ...] = (
         ),
         compute_error="",
     ),
-    # --- Compute-time (Plan D) K-1 scope gates, in enforcement order ---
-    # Order matches the old hand-coded _enforce_scope_gates so that tests
-    # asserting on which error fires first for a given scenario stay green.
+    # --- Compute-time K-1 scope gates, in enforcement order ---
+    # Order matches _enforce_scope_gates so that tests asserting on which
+    # error fires first for a given scenario stay green.
     Attestation(
         field="acknowledges_no_more_than_four_k1s",
         triggered_when=_more_than_four_k1s,

--- a/tenforty/attestations.py
+++ b/tenforty/attestations.py
@@ -1,0 +1,327 @@
+"""Data-driven attestation registry.
+
+Each Attestation describes a scope-out gate on TaxReturnConfig with a 3-way
+contract:
+- `None` at load → raise ValueError with `load_error` at load time.
+- `False` + `triggered_when(scenario)` truthy → raise NotImplementedError with
+  `compute_error` at compute time.
+- `True` → proceed (the scope-out path is accepted by the user).
+
+Single source of truth for the 13 Plan B + Plan D attestations. Both
+scenario._validate_scenario_config and sch_e_part_ii._enforce_scope_gates
+iterate this tuple rather than hand-coded `if ... is None: raise` blocks.
+
+Fixture/helper defaults are deliberately NOT on this dataclass. They live in
+`tests/helpers.plan_d_attestation_defaults()` so that changing what a simple
+in-memory test scenario implies (e.g., whether the user is assumed to have
+unlimited at-risk amounts when constructing a bare Scenario) is a helper
+change, reviewable independently from this registry.
+
+Compute-time ordering note: entries with triggered_when predicates that fire
+at sch_e_part_ii compute time appear in the same logical order as the old
+per-field checks they replace, so existing tests that assert on which error
+fires first for a given scenario remain green."""
+
+from dataclasses import dataclass
+from typing import Callable
+
+from tenforty.models import EntityType, Scenario
+
+
+@dataclass(frozen=True)
+class Attestation:
+    field: str
+    triggered_when: Callable[[Scenario], bool]
+    load_error: str
+    compute_error: str
+
+
+def _has_any_k1(s: Scenario) -> bool:
+    return bool(s.schedule_k1s)
+
+
+def _has_qbi(s: Scenario) -> bool:
+    return any(k1.qbi_amount for k1 in s.schedule_k1s)
+
+
+def _has_section_1231(s: Scenario) -> bool:
+    return any(k1.section_1231_gain for k1 in s.schedule_k1s)
+
+
+def _has_section_179(s: Scenario) -> bool:
+    return any(k1.section_179_deduction for k1 in s.schedule_k1s)
+
+
+def _has_partnership_se_earnings(s: Scenario) -> bool:
+    return any(
+        k1.entity_type == EntityType.PARTNERSHIP
+        and k1.partnership_self_employment_earnings
+        for k1 in s.schedule_k1s
+    )
+
+
+def _more_than_four_k1s(s: Scenario) -> bool:
+    return len(s.schedule_k1s) > 4
+
+
+def _never(s: Scenario) -> bool:
+    """Sentinel `triggered_when` predicate: never fires at compute time.
+
+    An attestation whose `triggered_when` is `_never` is enforced **only at
+    load time** — the `None → ValueError` gate in `validate_load_time` runs,
+    and `enforce_compute_time` skips the entry entirely.
+
+    Use this for attestations that:
+    - Raise eagerly in a different place (e.g. `has_foreign_accounts=True`
+      raises `NotImplementedError` immediately in `_validate_scenario_config`
+      because no scenario context makes a foreign account safe).
+    - Are enforced in a compute path outside `sch_e_part_ii._enforce_scope_gates`
+      (e.g. `acknowledges_form_8949_unsupported` is gated per-lot inside
+      `forms.sch_d`).
+    - Are user-awareness knobs with no runtime trigger (e.g.
+      `prior_year_itemized` configures the Sch 1 state-refund rule; an
+      unset value is rejected at load but the value itself does not cause
+      compute-time failure).
+
+    The inline comment on each `triggered_when=_never,` row is for quick
+    scanning; this docstring is the canonical reference."""
+    return False
+
+
+_ATTESTATIONS: tuple[Attestation, ...] = (
+    # --- Load-time-only (Plan B) attestations ---
+    Attestation(
+        field="has_foreign_accounts",
+        triggered_when=_never,  # True-branch raises at load; see scenario._validate_scenario_config.
+        load_error=(
+            "Scenario config field `has_foreign_accounts` is required and "
+            "must be either true or false. Schedule B Part III (Foreign "
+            "Accounts and Trusts) is not implemented in tenforty v1; if any "
+            "foreign financial account exists, this return will be "
+            "INCORRECT and you may be legally required to file FinCEN Form "
+            "114 (FBAR). You must answer this question explicitly in every "
+            "scenario."
+        ),
+        compute_error="",  # unused; True-at-load raises NotImplementedError eagerly
+    ),
+    Attestation(
+        field="acknowledges_form_8949_unsupported",
+        triggered_when=_never,  # enforced by forms.sch_d on a per-lot basis
+        load_error=(
+            "Scenario config field `acknowledges_form_8949_unsupported` is "
+            "required and must be either true or false. Form 8949 is not "
+            "implemented in tenforty v1. Lots with uncovered basis, basis "
+            "adjustments, or wash-sale reporting legally require Form 8949. "
+            "Set `false` if all 1099-B lots are covered-basis with no "
+            "adjustments (Sch D summary path applies and the return is "
+            "complete). Set `true` ONLY if you have reviewed any "
+            "8949-required lots and accept that they will be DROPPED from "
+            "Sch D totals (a warning is logged per dropped lot so you can "
+            "reconcile manually); your return will be INCOMPLETE for those "
+            "lots until 8949 support lands."
+        ),
+        compute_error="",
+    ),
+    Attestation(
+        field="acknowledges_sch_a_sales_tax_unsupported",
+        triggered_when=_never,  # enforced in forms.sch_a
+        load_error=(
+            "Scenario config field `acknowledges_sch_a_sales_tax_unsupported` "
+            "is required and must be either true or false. Schedule A line "
+            "5a offers a state-and-local INCOME TAX or GENERAL SALES TAX "
+            "election; tenforty v1 implements only the income-tax path. For "
+            "filers in no-state-income-tax states (TX, FL, WA, NV, SD, WY, "
+            "AK, TN, NH) the sales-tax election is usually the correct "
+            "choice and v1 cannot produce it. Set `false` if your state "
+            "levies an income tax (the income-tax path is correct for you). "
+            "Set `true` ONLY if you are in a no-income-tax state AND you "
+            "have reviewed the consequences — v1 will then raise "
+            "NotImplementedError from Sch A compute rather than silently "
+            "overstating your deduction."
+        ),
+        compute_error="",
+    ),
+    Attestation(
+        field="acknowledges_qbi_below_threshold",
+        triggered_when=_never,  # enforced in forms.f8995 (threshold + QBI > 0)
+        load_error=(
+            "Scenario config field `acknowledges_qbi_below_threshold` is "
+            "required and must be either true or false. Form 8995-A (full "
+            "QBI) is not implemented in tenforty v1; if a K-1 carries QBI "
+            "and taxable income exceeds the Rev. Proc. 2024-40 threshold, "
+            "compute will raise NotImplementedError."
+        ),
+        compute_error="",
+    ),
+    # --- Compute-time (Plan D) K-1 scope gates, in enforcement order ---
+    # Order matches the old hand-coded _enforce_scope_gates so that tests
+    # asserting on which error fires first for a given scenario stay green.
+    Attestation(
+        field="acknowledges_no_more_than_four_k1s",
+        triggered_when=_more_than_four_k1s,
+        load_error=(
+            "Scenario config field `acknowledges_no_more_than_four_k1s` is "
+            "required and must be either true or false. Schedule E Part II "
+            "continuation sheets (for more than 4 K-1s) are not implemented "
+            "in tenforty v1; compute will raise NotImplementedError if more "
+            "than 4 K-1s are present and this attestation is False."
+        ),
+        compute_error=(
+            "Scenario has more than 4 K-1s; Schedule E Part II continuation "
+            "is not implemented in tenforty v1. Set "
+            "`acknowledges_no_more_than_four_k1s: true` to accept that rows "
+            "beyond D will be dropped, or reduce to 4 K-1s."
+        ),
+    ),
+    Attestation(
+        field="acknowledges_unlimited_at_risk",
+        triggered_when=_has_any_k1,
+        load_error=(
+            "Scenario config field `acknowledges_unlimited_at_risk` is "
+            "required and must be either true or false. Form 6198 (at-risk "
+            "limitations) is not implemented in tenforty v1; compute will "
+            "raise NotImplementedError at Sch E Part II time if any K-1 is "
+            "present and this attestation is False."
+        ),
+        compute_error=(
+            "K-1 present but `acknowledges_unlimited_at_risk` (at_risk gate) "
+            "is false. Form 6198 (at-risk limitation) is not implemented in "
+            "tenforty v1; set the attestation to true to affirm all K-1 "
+            "activities have unlimited at-risk amounts."
+        ),
+    ),
+    Attestation(
+        field="basis_tracked_externally",
+        triggered_when=_has_any_k1,
+        load_error=(
+            "Scenario config field `basis_tracked_externally` is required "
+            "and must be either true or false. Shareholder/partner basis "
+            "worksheets (Form 7203 for S-corps, partner basis worksheet for "
+            "partnerships) are not implemented in tenforty v1; compute will "
+            "raise NotImplementedError at Sch E Part II time if any K-1 is "
+            "present and this attestation is False."
+        ),
+        compute_error=(
+            "K-1 present but `basis_tracked_externally` is false. tenforty "
+            "v1 does not compute stock/debt basis worksheets; set the "
+            "attestation to true to affirm basis is tracked outside this "
+            "system."
+        ),
+    ),
+    Attestation(
+        field="acknowledges_no_section_1231_gain",
+        triggered_when=_has_section_1231,
+        load_error=(
+            "Scenario config field `acknowledges_no_section_1231_gain` is "
+            "required and must be either true or false. Form 4797 (sales of "
+            "business property) is not implemented in tenforty v1; compute "
+            "will raise NotImplementedError if any K-1 carries nonzero "
+            "section_1231_gain and this attestation is False."
+        ),
+        compute_error=(
+            "K-1 reports section 1231 gain. Form 4797 is not implemented in "
+            "tenforty v1; set `acknowledges_no_section_1231_gain: true` "
+            "only if zero gain is correct."
+        ),
+    ),
+    Attestation(
+        field="acknowledges_no_section_179",
+        triggered_when=_has_section_179,
+        load_error=(
+            "Scenario config field `acknowledges_no_section_179` is "
+            "required and must be either true or false. The Section 179 "
+            "deduction (Form 4562 Part I) flowing through from K-1s is not "
+            "implemented in tenforty v1; compute will raise "
+            "NotImplementedError if any K-1 carries nonzero "
+            "section_179_deduction and this attestation is False."
+        ),
+        compute_error=(
+            "K-1 reports section 179 deduction. Section 179 at the 1040 "
+            "level is not implemented in tenforty v1; set "
+            "`acknowledges_no_section_179: true` if zero is correct."
+        ),
+    ),
+    Attestation(
+        field="acknowledges_no_partnership_se_earnings",
+        triggered_when=_has_partnership_se_earnings,
+        load_error=(
+            "Scenario config field `acknowledges_no_partnership_se_earnings` "
+            "is required and must be either true or false. Schedule SE is "
+            "not implemented in tenforty v1; compute will raise "
+            "NotImplementedError if a partnership K-1 carries nonzero "
+            "partnership_self_employment_earnings and this attestation is "
+            "False."
+        ),
+        compute_error=(
+            "Partnership K-1 reports SE earnings. Schedule SE is not "
+            "implemented in tenforty v1; set "
+            "`acknowledges_no_partnership_se_earnings: true` only if zero "
+            "is correct."
+        ),
+    ),
+    Attestation(
+        field="acknowledges_no_k1_credits",
+        triggered_when=_has_any_k1,
+        load_error=(
+            "Scenario config field `acknowledges_no_k1_credits` is required "
+            "and must be either true or false. K-1 box 13 (partnership) and "
+            "box 15 (S-corp) credits are not implemented in tenforty v1; "
+            "compute will raise NotImplementedError if this attestation is "
+            "False and any K-1 is present."
+        ),
+        compute_error=(
+            "K-1 present but `acknowledges_no_k1_credits` is false. K-1 box "
+            "13 / 15 credits are not implemented in tenforty v1; set the "
+            "attestation to true to affirm no K-1 credits apply."
+        ),
+    ),
+    # --- Load-time-only: user-awareness, not a compute trigger ---
+    Attestation(
+        field="acknowledges_no_estate_trust_k1",
+        triggered_when=_never,  # enforced unconditionally in sch_e_part_ii._enforce_scope_gates
+        load_error=(
+            "Scenario config field `acknowledges_no_estate_trust_k1` is "
+            "required and must be either true or false. Schedule E Part III "
+            "(estate and trust K-1 income) is not implemented in tenforty "
+            "v1; compute will raise NotImplementedError if any K-1 has "
+            "entity_type == 'estate_trust'. Declare this attestation even "
+            "when no estate/trust K-1 is present."
+        ),
+        compute_error="",
+    ),
+    Attestation(
+        field="prior_year_itemized",
+        triggered_when=_never,
+        load_error=(
+            "Scenario config field `prior_year_itemized` is required and "
+            "must be either true or false. It drives the 1099-G state-tax-"
+            "refund tax-benefit-rule on Schedule 1 line 1: if the prior "
+            "year used the standard deduction, the refund is not taxable; "
+            "if itemized, it is taxable up to the recovery limit."
+        ),
+        compute_error="",
+    ),
+)
+
+
+def validate_load_time(cfg) -> None:
+    """Iterate _ATTESTATIONS and raise ValueError for any None field.
+
+    Separate from compute-time enforcement because load runs before a
+    Scenario object exists (only TaxReturnConfig is constructed at this
+    point). Therefore `triggered_when` is not consulted here — any None
+    field raises regardless of whether the trigger would fire."""
+    for a in _ATTESTATIONS:
+        if getattr(cfg, a.field) is None:
+            raise ValueError(a.load_error)
+
+
+def enforce_compute_time(scenario: Scenario) -> None:
+    """Iterate _ATTESTATIONS and raise NotImplementedError for any field
+    whose trigger fires while the attestation is False."""
+    cfg = scenario.config
+    for a in _ATTESTATIONS:
+        if not a.triggered_when(scenario):
+            continue
+        if getattr(cfg, a.field) is False:
+            raise NotImplementedError(a.compute_error)

--- a/tenforty/forms/f4562.py
+++ b/tenforty/forms/f4562.py
@@ -52,7 +52,7 @@ _PROPERTY_METHOD = {
 def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     tax_year = scenario.config.year
     result: dict = {
-        "taxpayer_name": _format_taxpayer_name(scenario),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }
     assets_by_class: dict[str, list] = defaultdict(list)
@@ -123,7 +123,3 @@ def _convention_text(convention: str) -> str:
     }[convention]
 
 
-def _format_taxpayer_name(scenario: Scenario) -> str:
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
-    return f"{first} {last}".strip()

--- a/tenforty/forms/f4868.py
+++ b/tenforty/forms/f4868.py
@@ -32,7 +32,7 @@ def compute(scenario, upstream: dict[str, dict]) -> dict:
         f1040.get("total_tax"), f1040.get("total_payments")
     )
     return {
-        "full_name": f"{config.first_name} {config.last_name}".strip(),
+        "full_name": config.full_name,
         "ssn": config.ssn,
         "spouse_ssn": config.spouse_ssn,
         "address": config.address,

--- a/tenforty/forms/f8582.py
+++ b/tenforty/forms/f8582.py
@@ -141,8 +141,6 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
                 "suspended_amount": suspended,
             })
 
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
     return {
         "f8582_line_1a_activities_with_income": passive_income_total,
         "f8582_line_1b_activities_with_loss": passive_loss_total,
@@ -153,6 +151,6 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "f8582_line_11_allowed_loss": allowed_loss,
         "f8582_special_allowance": allowance,
         "per_activity_carryforwards": per_activity_carryforwards,
-        "taxpayer_name": f"{first} {last}".strip(),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }

--- a/tenforty/forms/f8582.py
+++ b/tenforty/forms/f8582.py
@@ -24,8 +24,7 @@ Consumes upstream["sch_e"] for Sch E Part I results — does NOT
 re-invoke forms.sch_e.compute, avoiding circular layering.
 """
 
-from tenforty.models import Scenario
-from tenforty.models import FilingStatus
+from tenforty.models import FilingStatus, K1FanoutData, Scenario
 from tenforty.rounding import irs_round
 
 
@@ -55,11 +54,19 @@ def special_allowance(
 
 
 def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
-    fanout = upstream.get("_k1_fanout", {})
+    fanout = upstream.get("k1_fanout") or K1FanoutData.empty()
     agi = float(upstream.get("f1040", {}).get("magi", 0))
     sch_e_upstream = upstream.get("sch_e", {})
 
-    passive_activities: list[dict] = list(fanout.get("passive_activities", []))
+    passive_activities: list[dict] = [
+        {
+            "entity_name": a.entity_name,
+            "income": a.income,
+            "loss": a.loss,
+            "prior_carryforward": a.prior_carryforward,
+        }
+        for a in fanout.passive_activities
+    ]
 
     # Sch E Part I rental property contributes to passive activities.
     if scenario.rental_properties:

--- a/tenforty/forms/f8582.py
+++ b/tenforty/forms/f8582.py
@@ -84,12 +84,8 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         a["prior_carryforward"] for a in passive_activities
     )
 
-    # Form 8582 MAGI (line 6) is AGI modified to exclude passive income/loss
-    # per the IRS line-6 instructions. The workbook formula is:
-    #   MAGI = Adj_Gross_Inc - PassiveIncomeLoss
-    # where PassiveIncomeLoss = line 3 (the net of all passive activities).
-    # Net passive activity = income - loss - prior_carryforward (negative
-    # when losses dominate). Subtracting a negative adds it back to AGI.
+    # Form 8582 MAGI (line 6) = AGI minus net passive activity. Subtracting a
+    # negative net (losses > income) adds the loss back, which is intentional.
     net_passive = passive_income_total - passive_loss_total - prior_carryforward_total
     magi = max(0.0, agi - net_passive)
 

--- a/tenforty/forms/f8959.py
+++ b/tenforty/forms/f8959.py
@@ -78,7 +78,7 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     line_24 = line_22 + line_23
 
     result: dict = {
-        "taxpayer_name": _format_taxpayer_name(scenario),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
         "f8959_line_1": irs_round(line_1),
         "f8959_line_2": irs_round(line_2),
@@ -126,7 +126,3 @@ def _cross_check(result: dict, key: str, oracle_value, oracle_name: str) -> None
         )
 
 
-def _format_taxpayer_name(scenario: Scenario) -> str:
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
-    return f"{first} {last}".strip()

--- a/tenforty/forms/f8995.py
+++ b/tenforty/forms/f8995.py
@@ -59,8 +59,6 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
 
     line_15 = min(line_6, line_14)
 
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
     return {
         "f8995_line_1_qbi": line_1,
         "f8995_line_2_total_qbi": line_2,
@@ -73,6 +71,6 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "f8995_line_13_subtract": line_13,
         "f8995_line_14_income_limit": line_14,
         "f8995_line_15_qbi_deduction": line_15,
-        "taxpayer_name": f"{first} {last}".strip(),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }

--- a/tenforty/forms/f8995.py
+++ b/tenforty/forms/f8995.py
@@ -16,20 +16,20 @@ under-state the deduction — documented limitation.
 """
 
 from tenforty.constants import y2025
-from tenforty.models import Scenario
+from tenforty.models import K1FanoutData, Scenario
 from tenforty.rounding import irs_round
 
 
 def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
-    fanout = upstream.get("_k1_fanout", {})
+    fanout = upstream.get("k1_fanout") or K1FanoutData.empty()
     f1040 = upstream.get("f1040", {})
 
     taxable_income = float(f1040.get("taxable_income_before_qbi_deduction", 0))
     net_cap_gain = float(f1040.get("net_capital_gain", 0))
     threshold = y2025.QBI_THRESHOLD[scenario.config.filing_status]
 
-    qbi_total = float(fanout.get("qbi_total", 0.0))
-    qualified_divs = float(fanout.get("qualified_dividends_total", 0.0))
+    qbi_total = fanout.qbi_aggregate
+    qualified_divs = fanout.qualified_dividends_aggregate
 
     if (qbi_total > 0
             and taxable_income > threshold

--- a/tenforty/forms/f8995.py
+++ b/tenforty/forms/f8995.py
@@ -1,18 +1,13 @@
-"""Form 8995 — Qualified Business Income Deduction Simplified Computation.
+"""Form 8995 — Qualified Business Income Deduction (simplified).
 
-v1 scope: simple path only. When taxable income exceeds the Rev. Proc.
-2024-40 threshold AND the scenario actually has QBI to deduct, the
-scenario must attest with `acknowledges_qbi_below_threshold: true` to
-accept that the simple path is being used in place of Form 8995-A
-(scoped out of v1). If qbi_total == 0 the threshold gate is
-unconditionally skipped — there is no deduction to compute.
+Scope: v1 simple path only. Over-threshold scenarios with nonzero QBI
+require Form 8995-A (not implemented) and raise NotImplementedError at
+compute time — the gate message carries the full explanation.
 
-net_capital_gain simplification (v1): per Form 8995 Inst, the correct
-figure is `qualified_dividends + net_LTCG − net_STCL`. v1 narrows to
-`qualified_dividends + max(0, net_LTCG)`, since K-1-only scenarios
-rarely realize a net short-term capital loss worth netting. Scenarios
-with a meaningful STCL will slightly over-state the income limit and
-under-state the deduction — documented limitation.
+net_capital_gain simplification: v1 uses `qualified_dividends + max(0,
+net_LTCG)` in place of `qualified_dividends + net_LTCG − net_STCL`.
+K-1-only scenarios rarely realize a meaningful STCL worth netting; a
+scenario with a meaningful STCL will slightly under-state the deduction.
 """
 
 from tenforty.constants import y2025

--- a/tenforty/forms/sch_1.py
+++ b/tenforty/forms/sch_1.py
@@ -93,8 +93,6 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         + other_adjustments_line_24_sum
     )
 
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
     return {
         "sch_1_line_1_taxable_refunds": taxable_refunds_line_1,
         "sch_1_line_3_business_income": business_income_line_3,
@@ -111,6 +109,6 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "sch_1_line_20_ira": ira_deduction_line_20,
         "sch_1_line_21_student_loan_interest": student_loan_interest_line_21,
         "sch_1_line_26_total_adjustments": total_adjustments_line_26,
-        "taxpayer_name": f"{first} {last}".strip(),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }

--- a/tenforty/forms/sch_1.py
+++ b/tenforty/forms/sch_1.py
@@ -14,7 +14,7 @@ the variables by name, so the wiring is a one-line edit.
 """
 
 from tenforty.constants import y2025
-from tenforty.models import FilingStatus, Scenario
+from tenforty.models import Scenario
 from tenforty.rounding import irs_round
 
 
@@ -38,7 +38,7 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         standard = float(scenario.config.prior_year_standard_deduction_amount or 0)
         recovery_cap = max(0.0, itemized - standard)
         salt_cap = float(
-            y2025.PRIOR_YEAR_SALT_CAP[FilingStatus(scenario.config.filing_status)]
+            y2025.PRIOR_YEAR_SALT_CAP[scenario.config.filing_status]
         )
         taxable_refunds_line_1 = irs_round(
             min(refund_total, recovery_cap, salt_cap)

--- a/tenforty/forms/sch_a.py
+++ b/tenforty/forms/sch_a.py
@@ -105,8 +105,6 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         + line_16_other
     )
 
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
     return {
         "sch_a_line_1_medical_gross": medical_gross,
         "sch_a_line_2_agi": agi,
@@ -128,6 +126,6 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "sch_a_line_15_casualty": line_15_casualty,
         "sch_a_line_16_other": line_16_other,
         "sch_a_line_17_total": line_17_total,
-        "taxpayer_name": f"{first} {last}".strip(),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }

--- a/tenforty/forms/sch_b.py
+++ b/tenforty/forms/sch_b.py
@@ -60,12 +60,8 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "taxable_interest": total_interest,
         "dividend_payers": dividend_payers,
         "total_ordinary_dividends": total_dividends,
-        "taxpayer_name": _format_taxpayer_name(scenario),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }
 
 
-def _format_taxpayer_name(scenario: Scenario) -> str:
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
-    return f"{first} {last}".strip()

--- a/tenforty/forms/sch_b.py
+++ b/tenforty/forms/sch_b.py
@@ -5,7 +5,7 @@ scenario and returns PDF-ready result keys.
 
 v1 scope: Parts I and II only. Part III (Foreign Accounts and Trusts)
 is gated at scenario load via ``TaxReturnConfig.has_foreign_accounts``
-(see #11 Task 6) — scenarios with ``True`` fail load with
+— scenarios with ``True`` fail load with
 ``NotImplementedError``, so any scenario reaching this compute has
 attested ``False``. Part III / FinCEN 114 (FBAR) support is tracked as
 a follow-up.

--- a/tenforty/forms/sch_b.py
+++ b/tenforty/forms/sch_b.py
@@ -17,7 +17,7 @@ the mapping module so they stay in sync with the PDF geometry.
 """
 
 from tenforty.mappings.pdf_sch_b import DIVIDEND_MAX_ROWS, INTEREST_MAX_ROWS
-from tenforty.models import Scenario
+from tenforty.models import K1FanoutData, Scenario
 from tenforty.rounding import irs_round
 
 
@@ -31,11 +31,11 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         for e in scenario.form1099_div
     ]
 
-    fanout = upstream.get("_k1_fanout", {})
-    for row in fanout.get("interest_from_k1s", []):
-        interest_payers.append({"payer": row["payer"], "amount": row["amount"]})
-    for row in fanout.get("ordinary_dividends_from_k1s", []):
-        dividend_payers.append({"payer": row["payer"], "amount": row["amount"]})
+    fanout = upstream.get("k1_fanout") or K1FanoutData.empty()
+    for pa in fanout.sch_b_interest_additions:
+        interest_payers.append({"payer": pa.payer, "amount": irs_round(pa.amount)})
+    for pa in fanout.sch_b_dividend_additions:
+        dividend_payers.append({"payer": pa.payer, "amount": irs_round(pa.amount)})
 
     if len(interest_payers) > INTEREST_MAX_ROWS:
         raise NotImplementedError(

--- a/tenforty/forms/sch_d.py
+++ b/tenforty/forms/sch_d.py
@@ -23,7 +23,7 @@ forces an explicit attestation at scenario load.
 
 import logging
 
-from tenforty.models import Form1099B, Scenario
+from tenforty.models import Form1099B, K1FanoutData, Scenario
 from tenforty.rounding import irs_round
 
 log = logging.getLogger(__name__)
@@ -67,9 +67,9 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     short = _summarize(short_lots)
     lng = _summarize(long_lots)
 
-    fanout = upstream.get("_k1_fanout", {})
-    k1_short = irs_round(fanout.get("short_term_cap_gain_from_k1s", 0.0))
-    k1_long = irs_round(fanout.get("long_term_cap_gain_from_k1s", 0.0))
+    fanout = upstream.get("k1_fanout") or K1FanoutData.empty()
+    k1_short = irs_round(sum(fanout.sch_d_short_term_additions))
+    k1_long = irs_round(sum(fanout.sch_d_long_term_additions))
 
     return {
         "sch_d_line_1a_proceeds": short["proceeds"],

--- a/tenforty/forms/sch_d.py
+++ b/tenforty/forms/sch_d.py
@@ -83,7 +83,7 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "sch_d_line_12_net_long_k1": k1_long,
         "sch_d_line_15_net_long": lng["gain"] + k1_long,
         "sch_d_line_16_total": (short["gain"] + k1_short) + (lng["gain"] + k1_long),
-        "taxpayer_name": _format_taxpayer_name(scenario),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }
 
@@ -94,7 +94,3 @@ def _summarize(lots: list[Form1099B]) -> dict:
     return {"proceeds": proceeds, "basis": basis, "gain": proceeds - basis}
 
 
-def _format_taxpayer_name(scenario: Scenario) -> str:
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
-    return f"{first} {last}".strip()

--- a/tenforty/forms/sch_e.py
+++ b/tenforty/forms/sch_e.py
@@ -92,18 +92,11 @@ def _property_a_fields(rp: RentalProperty) -> dict:
 def has_any_net_loss(scenario: Scenario) -> bool:
     """True when any Sch E Part I rental runs a net loss.
 
-    Single-purpose helper for orchestrator predicates. Does not go
-    through compute() — just sums the scenario's own fields.
-    """
+    Iterates _EXPENSE_FIELDS so that adding or removing an expense line
+    here keeps the predicate in sync without a second edit."""
     for p in scenario.rental_properties:
-        expense_fields = (
-            p.advertising, p.auto_and_travel, p.cleaning_and_maintenance,
-            p.commissions, p.insurance, p.legal_and_professional_fees,
-            p.management_fees, p.mortgage_interest, p.other_interest,
-            p.repairs, p.supplies, p.taxes, p.utilities, p.depreciation,
-            p.other_expenses,
-        )
-        if p.rents_received < sum(expense_fields):
+        expense_total = sum(getattr(p, attr) for attr, _key in _EXPENSE_FIELDS)
+        if p.rents_received < expense_total:
             return True
     return False
 

--- a/tenforty/forms/sch_e.py
+++ b/tenforty/forms/sch_e.py
@@ -43,7 +43,7 @@ _EXPENSE_FIELDS = (
 def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     f1040 = upstream.get("f1040", {})
     result: dict = {
-        "taxpayer_name": _format_taxpayer_name(scenario),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }
     if not scenario.rental_properties:
@@ -101,7 +101,3 @@ def has_any_net_loss(scenario: Scenario) -> bool:
     return False
 
 
-def _format_taxpayer_name(scenario: Scenario) -> str:
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
-    return f"{first} {last}".strip()

--- a/tenforty/forms/sch_e_part_ii.py
+++ b/tenforty/forms/sch_e_part_ii.py
@@ -26,7 +26,10 @@ behavior is to ignore, not raise.
 
 import logging
 
-from tenforty.models import EntityType, Scenario, ScheduleK1
+from tenforty.models import (
+    EntityType, K1FanoutActivity, K1FanoutData, PayerAmount,
+    Scenario, ScheduleK1,
+)
 from tenforty.rounding import irs_round
 
 
@@ -35,23 +38,23 @@ log = logging.getLogger(__name__)
 _ROW_LETTERS = ("a", "b", "c", "d")
 
 
-def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
+def compute(
+    scenario: Scenario, upstream: dict,
+) -> tuple[dict, K1FanoutData]:
     _enforce_scope_gates(scenario)
 
     result: dict = {
-        "taxpayer_name": _format_taxpayer_name(scenario),
+        "taxpayer_name": scenario.config.full_name,
         "taxpayer_ssn": scenario.config.ssn,
     }
 
-    fanout = {
-        "interest_from_k1s": [],
-        "ordinary_dividends_from_k1s": [],
-        "qualified_dividends_total": 0.0,
-        "short_term_cap_gain_from_k1s": 0.0,
-        "long_term_cap_gain_from_k1s": 0.0,
-        "qbi_total": 0.0,
-        "passive_activities": [],
-    }
+    interest_additions: list[PayerAmount] = []
+    dividend_additions: list[PayerAmount] = []
+    short_term_additions: list[float] = []
+    long_term_additions: list[float] = []
+    passive_activities: list[K1FanoutActivity] = []
+    qbi_aggregate = 0.0
+    qualified_dividends_aggregate = 0.0
 
     line_29a_passive_income = 0
     line_29a_passive_loss = 0
@@ -63,11 +66,14 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         row = _row_fields(k1, letter)
         result.update(row)
 
-        ord_biz = irs_round(k1.ordinary_business_income)
-        rental = irs_round(k1.net_rental_real_estate + k1.other_net_rental)
-        roy = irs_round(k1.royalties)
-        other = irs_round(k1.other_income)
-        total_row = ord_biz + rental + roy + other
+        # Row total duplicated here and in _row_fields; Task 14 extracts
+        # _k1_row_total(k1) to eliminate the duplication with its own test.
+        total_row = (
+            irs_round(k1.ordinary_business_income)
+            + irs_round(k1.net_rental_real_estate + k1.other_net_rental)
+            + irs_round(k1.royalties)
+            + irs_round(k1.other_income)
+        )
 
         if k1.material_participation:
             if total_row >= 0:
@@ -78,9 +84,9 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
                 log.warning(
                     "K-1 %r has material_participation=True but also a "
                     "prior_year_passive_loss_carryforward of %s; "
-                    "dropping the carryforward (cannot mix active and "
-                    "suspended-passive in the same year). Track the "
-                    "carryforward externally until disposition.",
+                    "dropping (cannot mix active and suspended-passive "
+                    "in the same year). Track the carryforward externally "
+                    "until disposition.",
                     k1.entity_name, k1.prior_year_passive_loss_carryforward,
                 )
         else:
@@ -88,36 +94,38 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
                 line_29a_passive_income += total_row
             else:
                 line_29a_passive_loss += -total_row
-            fanout["passive_activities"].append({
-                "entity_name": k1.entity_name,
-                "income": max(0, total_row),
-                "loss": max(0, -total_row),
-                "prior_carryforward": irs_round(
-                    k1.prior_year_passive_loss_carryforward,
+            passive_activities.append(K1FanoutActivity(
+                entity_name=k1.entity_name,
+                entity_ein=k1.entity_ein,
+                entity_type=k1.entity_type,
+                income=float(max(0, total_row)),
+                loss=float(max(0, -total_row)),
+                prior_carryforward=float(
+                    irs_round(k1.prior_year_passive_loss_carryforward),
                 ),
-            })
+            ))
 
         if k1.interest_income:
-            fanout["interest_from_k1s"].append(
-                {"payer": k1.entity_name, "amount": float(k1.interest_income)},
+            interest_additions.append(
+                PayerAmount(payer=k1.entity_name, amount=float(k1.interest_income)),
             )
         if k1.ordinary_dividends:
-            fanout["ordinary_dividends_from_k1s"].append(
-                {"payer": k1.entity_name,
-                 "amount": float(k1.ordinary_dividends)},
+            dividend_additions.append(
+                PayerAmount(
+                    payer=k1.entity_name, amount=float(k1.ordinary_dividends),
+                ),
             )
-        fanout["qualified_dividends_total"] += k1.qualified_dividends
-        fanout["short_term_cap_gain_from_k1s"] += k1.net_short_term_capital_gain
-        fanout["long_term_cap_gain_from_k1s"] += k1.net_long_term_capital_gain
-        fanout["qbi_total"] += k1.qbi_amount
+        qualified_dividends_aggregate += k1.qualified_dividends
+        short_term_additions.append(float(k1.net_short_term_capital_gain))
+        long_term_additions.append(float(k1.net_long_term_capital_gain))
+        qbi_aggregate += k1.qbi_amount
 
     result["sch_e_line_29a_total_passive_income"] = line_29a_passive_income
     result["sch_e_line_29b_total_passive_loss"] = line_29a_passive_loss
     result["sch_e_line_29a_total_nonpassive_income"] = line_29a_nonpassive_income
     result["sch_e_line_29b_total_nonpassive_loss"] = line_29a_nonpassive_loss
-    # Line 32 = partnership + s-corp subtotal. Line 37 (estate/trust) is
-    # unconditionally 0 in Plan D — estate/trust K-1s are rejected at the
-    # scope gate above, so nothing ever reaches Part III.
+    # Line 37 (estate/trust) is always 0: estate_trust K-1s are rejected by
+    # _enforce_scope_gates, so nothing reaches Part III.
     result["sch_e_line_32_total_partnership_scorp"] = (
         line_29a_passive_income + line_29a_nonpassive_income
         - line_29a_passive_loss - line_29a_nonpassive_loss
@@ -125,8 +133,16 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     result["sch_e_line_37_total_estate_trust"] = 0
     result["sch_e_line_41_total_pte"] = result["sch_e_line_32_total_partnership_scorp"]
 
-    result["_k1_fanout"] = fanout
-    return result
+    fanout = K1FanoutData(
+        sch_b_interest_additions=tuple(interest_additions),
+        sch_b_dividend_additions=tuple(dividend_additions),
+        sch_d_short_term_additions=tuple(short_term_additions),
+        sch_d_long_term_additions=tuple(long_term_additions),
+        qbi_aggregate=qbi_aggregate,
+        qualified_dividends_aggregate=qualified_dividends_aggregate,
+        passive_activities=tuple(passive_activities),
+    )
+    return result, fanout
 
 
 def _enforce_scope_gates(scenario: Scenario) -> None:
@@ -226,9 +242,3 @@ def _row_fields(k1: ScheduleK1, letter: str) -> dict:
         f"sch_e_part_ii_row_{letter}_nonpassive_income": nonpassive_income,
         f"sch_e_part_ii_row_{letter}_nonpassive_loss": nonpassive_loss,
     }
-
-
-def _format_taxpayer_name(scenario: Scenario) -> str:
-    first = scenario.config.first_name.strip()
-    last = scenario.config.last_name.strip()
-    return f"{first} {last}".strip()

--- a/tenforty/forms/sch_e_part_ii.py
+++ b/tenforty/forms/sch_e_part_ii.py
@@ -26,6 +26,7 @@ behavior is to ignore, not raise.
 
 import logging
 
+from tenforty.attestations import enforce_compute_time
 from tenforty.models import (
     EntityType, K1FanoutActivity, K1FanoutData, PayerAmount,
     Scenario, ScheduleK1,
@@ -146,13 +147,15 @@ def compute(
 
 
 def _enforce_scope_gates(scenario: Scenario) -> None:
-    k1s = scenario.schedule_k1s
-    if not k1s:
-        return
-    cfg = scenario.config
-    # Estate/trust K-1 — unconditional NotImplementedError (attestation
-    # is for user awareness, not "proceed naively").
-    for k1 in k1s:
+    """Compute-time scope-out enforcement.
+
+    Two parts:
+    1. estate_trust K-1 — unconditional NotImplementedError regardless of
+       attestation (Schedule E Part III is not implemented; the attestation
+       is user-awareness only).
+    2. All other gates driven by _ATTESTATIONS.enforce_compute_time.
+    """
+    for k1 in scenario.schedule_k1s:
         if k1.entity_type == EntityType.ESTATE_TRUST:
             raise NotImplementedError(
                 f"K-1 {k1.entity_name!r} has entity_type='estate_trust'. "
@@ -162,58 +165,7 @@ def _enforce_scope_gates(scenario: Scenario) -> None:
                 "(`acknowledges_no_estate_trust_k1` is a load-time "
                 "user-awareness gate only; it does not enable compute.)"
             )
-    if len(k1s) > 4 and not cfg.acknowledges_no_more_than_four_k1s:
-        raise NotImplementedError(
-            f"Scenario has {len(k1s)} K-1s; Schedule E Part II "
-            "continuation (beyond 4 rows) is not implemented in tenforty "
-            "v1. Set `acknowledges_no_more_than_four_k1s: true` to accept "
-            "that rows beyond D will be dropped, or reduce to 4 K-1s."
-        )
-    if not cfg.acknowledges_unlimited_at_risk:
-        raise NotImplementedError(
-            "K-1 present but `acknowledges_unlimited_at_risk` is false. "
-            "Form 6198 (at-risk limitation) is not implemented in "
-            "tenforty v1; set the attestation to true to affirm all K-1 "
-            "activities have unlimited at-risk amounts."
-        )
-    if not cfg.basis_tracked_externally:
-        raise NotImplementedError(
-            "K-1 present but `basis_tracked_externally` is false. "
-            "tenforty v1 does not compute stock/debt basis worksheets; "
-            "set the attestation to true to affirm basis is tracked "
-            "outside this system."
-        )
-    for k1 in k1s:
-        if k1.section_1231_gain and not cfg.acknowledges_no_section_1231_gain:
-            raise NotImplementedError(
-                f"K-1 {k1.entity_name!r} reports section 1231 gain "
-                f"{k1.section_1231_gain}. Form 4797 is not implemented "
-                "in tenforty v1; set `acknowledges_no_section_1231_gain: "
-                "true` only if zero gain is correct."
-            )
-        if k1.section_179_deduction and not cfg.acknowledges_no_section_179:
-            raise NotImplementedError(
-                f"K-1 {k1.entity_name!r} reports section 179 deduction "
-                f"{k1.section_179_deduction}. Section 179 at the 1040 "
-                "level is not implemented in tenforty v1; set "
-                "`acknowledges_no_section_179: true` if zero is correct."
-            )
-        if (k1.entity_type == EntityType.PARTNERSHIP
-                and k1.partnership_self_employment_earnings
-                and not cfg.acknowledges_no_partnership_se_earnings):
-            raise NotImplementedError(
-                f"Partnership K-1 {k1.entity_name!r} reports SE "
-                f"earnings {k1.partnership_self_employment_earnings}. "
-                "Schedule SE is not implemented in tenforty v1; set "
-                "`acknowledges_no_partnership_se_earnings: true` only if "
-                "zero is correct."
-            )
-    if not cfg.acknowledges_no_k1_credits:
-        raise NotImplementedError(
-            "K-1 present but `acknowledges_no_k1_credits` is false. K-1 "
-            "box 13 / 15 credits are not implemented in tenforty v1; set "
-            "the attestation to true to affirm no K-1 credits apply."
-        )
+    enforce_compute_time(scenario)
 
 
 def _row_fields(k1: ScheduleK1, letter: str) -> dict:

--- a/tenforty/forms/sch_e_part_ii.py
+++ b/tenforty/forms/sch_e_part_ii.py
@@ -39,6 +39,18 @@ log = logging.getLogger(__name__)
 _ROW_LETTERS = ("a", "b", "c", "d")
 
 
+def _k1_row_total(k1: ScheduleK1) -> float:
+    """Sum of the Sch E Part II row components per K-1, IRS-rounded
+    per component (rentals are combined before rounding, matching the
+    form's single 'Rental real estate' line)."""
+    return (
+        irs_round(k1.ordinary_business_income)
+        + irs_round(k1.net_rental_real_estate + k1.other_net_rental)
+        + irs_round(k1.royalties)
+        + irs_round(k1.other_income)
+    )
+
+
 def compute(
     scenario: Scenario, upstream: dict,
 ) -> tuple[dict, K1FanoutData]:
@@ -67,14 +79,7 @@ def compute(
         row = _row_fields(k1, letter)
         result.update(row)
 
-        # Row total duplicated here and in _row_fields; Task 14 extracts
-        # _k1_row_total(k1) to eliminate the duplication with its own test.
-        total_row = (
-            irs_round(k1.ordinary_business_income)
-            + irs_round(k1.net_rental_real_estate + k1.other_net_rental)
-            + irs_round(k1.royalties)
-            + irs_round(k1.other_income)
-        )
+        total_row = _k1_row_total(k1)
 
         if k1.material_participation:
             if total_row >= 0:
@@ -169,11 +174,7 @@ def _enforce_scope_gates(scenario: Scenario) -> None:
 
 
 def _row_fields(k1: ScheduleK1, letter: str) -> dict:
-    ord_biz = irs_round(k1.ordinary_business_income)
-    rental = irs_round(k1.net_rental_real_estate + k1.other_net_rental)
-    roy = irs_round(k1.royalties)
-    other = irs_round(k1.other_income)
-    total = ord_biz + rental + roy + other
+    total = _k1_row_total(k1)
     passive_income = passive_loss = nonpassive_income = nonpassive_loss = 0
     if k1.material_participation:
         if total >= 0:

--- a/tenforty/forms/sch_e_part_ii.py
+++ b/tenforty/forms/sch_e_part_ii.py
@@ -6,7 +6,7 @@ and Form 8582 (passive activity loss).
 
 **Scope:** Partnership (1065) and S-corp (1120-S) K-1s only. 1041
 (estate/trust) K-1s belong on Schedule E Part III, which is NOT
-implemented in Plan D — encountering any K-1 with
+implemented in tenforty v1 — encountering any K-1 with
 ``entity_type == "estate_trust"`` raises NotImplementedError regardless
 of the ``acknowledges_no_estate_trust_k1`` attestation (the attestation
 is a user-awareness checkbox, not a "proceed naively" flag).
@@ -20,7 +20,7 @@ Note on prior-year passive-loss carryforward: when
 ``prior_year_passive_loss_carryforward`` on that K-1 is dropped — an
 activity cannot shift between passive and nonpassive in a single year,
 and any prior suspended loss should remain suspended until disposition
-(out of scope for Plan D). We log a WARN in that case; the compute-time
+(out of scope for tenforty v1). We log a WARN in that case; the compute-time
 behavior is to ignore, not raise.
 """
 
@@ -165,7 +165,7 @@ def _enforce_scope_gates(scenario: Scenario) -> None:
             raise NotImplementedError(
                 f"K-1 {k1.entity_name!r} has entity_type='estate_trust'. "
                 "1041 K-1 income belongs on Sch E Part III (lines 33-37), "
-                "which is NOT implemented in Plan D. Scope out: remove "
+                "which is NOT implemented in tenforty v1. Scope out: remove "
                 "the K-1 or wait for Part III support. "
                 "(`acknowledges_no_estate_trust_k1` is a load-time "
                 "user-awareness gate only; it does not enable compute.)"

--- a/tenforty/forms/sch_e_part_ii.py
+++ b/tenforty/forms/sch_e_part_ii.py
@@ -26,7 +26,7 @@ behavior is to ignore, not raise.
 
 import logging
 
-from tenforty.models import Scenario, ScheduleK1
+from tenforty.models import EntityType, Scenario, ScheduleK1
 from tenforty.rounding import irs_round
 
 
@@ -137,7 +137,7 @@ def _enforce_scope_gates(scenario: Scenario) -> None:
     # Estate/trust K-1 — unconditional NotImplementedError (attestation
     # is for user awareness, not "proceed naively").
     for k1 in k1s:
-        if k1.entity_type == "estate_trust":
+        if k1.entity_type == EntityType.ESTATE_TRUST:
             raise NotImplementedError(
                 f"K-1 {k1.entity_name!r} has entity_type='estate_trust'. "
                 "1041 K-1 income belongs on Sch E Part III (lines 33-37), "
@@ -182,7 +182,7 @@ def _enforce_scope_gates(scenario: Scenario) -> None:
                 "level is not implemented in tenforty v1; set "
                 "`acknowledges_no_section_179: true` if zero is correct."
             )
-        if (k1.entity_type == "partnership"
+        if (k1.entity_type == EntityType.PARTNERSHIP
                 and k1.partnership_self_employment_earnings
                 and not cfg.acknowledges_no_partnership_se_earnings):
             raise NotImplementedError(
@@ -220,7 +220,7 @@ def _row_fields(k1: ScheduleK1, letter: str) -> dict:
     return {
         f"sch_e_part_ii_row_{letter}_name": k1.entity_name,
         f"sch_e_part_ii_row_{letter}_ein": k1.entity_ein,
-        f"sch_e_part_ii_row_{letter}_entity_type_{k1.entity_type}": "X",
+        f"sch_e_part_ii_row_{letter}_entity_type_{k1.entity_type.value}": "X",
         f"sch_e_part_ii_row_{letter}_passive_income": passive_income,
         f"sch_e_part_ii_row_{letter}_passive_loss": passive_loss,
         f"sch_e_part_ii_row_{letter}_nonpassive_income": nonpassive_income,

--- a/tenforty/mappings/f1040.py
+++ b/tenforty/mappings/f1040.py
@@ -56,7 +56,7 @@ class F1040(FormMapping):
             # are intentionally deferred: the form's Part II table aggregates
             # K-1 income into four columns (passive/nonpassive * income/loss)
             # that require per-K-1 routing based on material_participation
-
+            # and box type; aggregation is deferred until that routing is implemented.
             "k1_a_entity_name": "Sch. E",
             "k1_a_entity_type_s_corp": "Sch. E",
             "k1_a_entity_type_partnership": "Sch. E",

--- a/tenforty/mappings/f1040.py
+++ b/tenforty/mappings/f1040.py
@@ -56,7 +56,7 @@ class F1040(FormMapping):
             # are intentionally deferred: the form's Part II table aggregates
             # K-1 income into four columns (passive/nonpassive * income/loss)
             # that require per-K-1 routing based on material_participation
-            # and box type — Task 3 will add that aggregation.
+
             "k1_a_entity_name": "Sch. E",
             "k1_a_entity_type_s_corp": "Sch. E",
             "k1_a_entity_type_partnership": "Sch. E",

--- a/tenforty/mappings/pdf_sch_b.py
+++ b/tenforty/mappings/pdf_sch_b.py
@@ -2,15 +2,15 @@
 
 Parts I and II only. Part III (Foreign Accounts and Trusts) is not
 implemented in tenforty v1; the scope-out is enforced at scenario load
-via ``TaxReturnConfig.has_foreign_accounts`` (see #11 Task 6), so any
+via ``TaxReturnConfig.has_foreign_accounts``, so any
 scenario reaching this mapping has already attested ``False``. Part III
 / FinCEN 114 (FBAR) support is tracked as a follow-up.
 
 The 2025 Sch B PDF uses flat, sequential field names (``f1_01`` through
 ``f1_66``) rather than row-grouped names (e.g. ``Row1.f1_X``), so the
-{i}-repeater shape introduced in Plan B Task 1 does not apply cleanly
-here. The mapping declares every payer/amount slot as an explicit
-scalar. Compute (Task 8) writes slots 1..N for N payers and leaves the
+{i}-repeater shape used by other forms does not apply cleanly here.
+The mapping declares every payer/amount slot as an explicit scalar.
+Compute writes slots 1..N for N payers and leaves the
 remaining slots unset; overflow is enforced in compute against the
 14-interest / 16-dividend row caps.
 

--- a/tenforty/mappings/pdf_sch_e.py
+++ b/tenforty/mappings/pdf_sch_e.py
@@ -3,8 +3,8 @@
 v1 scope: single rental property (slot A on Page 1). Property slots B
 and C exist on the form but are not populated by v1 compute.
 
-Plan D extends this mapping with Part II (partnerships, S corps via K-1)
-on Page 2.  The page-2 header fields (taxpayer_name_page2 / taxpayer_ssn_page2)
+Part II (partnerships, S-corps via K-1) shares the Page 2 table frame.
+The page-2 header fields (taxpayer_name_page2 / taxpayer_ssn_page2)
 are mapping-layer concerns — the orchestrator derives them from the compute
 outputs (taxpayer_name / taxpayer_ssn) when merging Part I + Part II values.
 That way compute never leaks PDF-template structure.
@@ -21,7 +21,7 @@ Page 2 field discovery notes (2025 form):
     (g) nonpassive loss, (h) §179 (skipped in v1), (i) nonpassive income.
   - Line 29a/b totals at y≈480/468 (f2_35–f2_44, five cols each).
   - Lines 30/31/32 single-column totals (f2_45/f2_46/f2_47).
-  - Line 37 estate/trust total (f2_68) — always 0 in Plan D.
+  - Line 37 estate/trust total (f2_68) — always 0: estate_trust K-1s are rejected at load.
   - Line 41 total pass-through (f2_76).
 """
 
@@ -173,7 +173,7 @@ class PdfSchE:
                 "sch_e_line_31_total_loss":      f"{_P2}.f2_46[0]",
                 "sch_e_line_32_total_partnership_scorp": f"{_P2}.f2_47[0]",
 
-                # ── Part III — Line 37 (estate/trust) — always 0 in Plan D ────
+                # ── Part III — Line 37 (estate/trust) — always 0 in v1 ────
                 "sch_e_line_37_total_estate_trust": f"{_P2}.f2_68[0]",
 
                 # ── Line 41 — total pass-through income / (loss) ───────────────

--- a/tenforty/mappings/pdf_sch_e.py
+++ b/tenforty/mappings/pdf_sch_e.py
@@ -173,7 +173,7 @@ class PdfSchE:
                 "sch_e_line_31_total_loss":      f"{_P2}.f2_46[0]",
                 "sch_e_line_32_total_partnership_scorp": f"{_P2}.f2_47[0]",
 
-                # ── Part III — Line 37 (estate/trust) — always 0 in v1 ────
+                # ── Part III — Line 37 (estate/trust) — always 0: estate_trust K-1s rejected at load ────
                 "sch_e_line_37_total_estate_trust": f"{_P2}.f2_68[0]",
 
                 # ── Line 41 — total pass-through income / (loss) ───────────────

--- a/tenforty/mappings/pdf_sch_e.py
+++ b/tenforty/mappings/pdf_sch_e.py
@@ -29,6 +29,37 @@ _P2 = "topmostSubform[0].Page2[0]"
 _T28AF = f"{_P2}.Table_Line28a-f[0]"
 _T28GK = f"{_P2}.Table_Line28g-k[0]"
 
+_ROWS = ("A", "B", "C", "D")
+
+
+def _row_mapping(row_letter: str) -> dict[str, str]:
+    """Return the 8 PDF field entries for one Part II Line 28 row (A–D).
+
+    Field-number strides within the form:
+      AF sub-table (name, EIN, checkboxes) — +3 per row:
+        name f2_(3,6,9,12), EIN f2_(4,7,10,13),
+        partnership checkbox c2_(2,5,8,11), S-corp checkbox c2_(3,6,9,12)
+      GK sub-table (income/loss columns) — +5 per row:
+        passive_loss f2_(15,20,25,30), passive_income f2_(16,21,26,31),
+        nonpassive_loss f2_(17,22,27,32),
+        nonpassive_income f2_(19,24,29,34)  ← skips §179 at offset +2
+    To add Row E: append "E" to _ROWS; strides extend automatically.
+    """
+    i = _ROWS.index(row_letter)
+    row = row_letter.lower()
+    af = f"{_T28AF}.Row{row_letter}[0]"
+    gk = f"{_T28GK}.Row{row_letter}[0]"
+    return {
+        f"sch_e_part_ii_row_{row}_name":                     f"{af}.f2_{3 + 3 * i}[0]",
+        f"sch_e_part_ii_row_{row}_ein":                      f"{af}.f2_{4 + 3 * i}[0]",
+        f"sch_e_part_ii_row_{row}_entity_type_partnership":  f"{af}.c2_{2 + 3 * i}[0]",
+        f"sch_e_part_ii_row_{row}_entity_type_s_corp":       f"{af}.c2_{3 + 3 * i}[0]",
+        f"sch_e_part_ii_row_{row}_passive_loss":             f"{gk}.f2_{15 + 5 * i}[0]",
+        f"sch_e_part_ii_row_{row}_passive_income":           f"{gk}.f2_{16 + 5 * i}[0]",
+        f"sch_e_part_ii_row_{row}_nonpassive_loss":          f"{gk}.f2_{17 + 5 * i}[0]",
+        f"sch_e_part_ii_row_{row}_nonpassive_income":        f"{gk}.f2_{19 + 5 * i}[0]",
+    }
+
 
 class PdfSchE:
     _MAPPINGS: dict[int, dict] = {
@@ -108,81 +139,12 @@ class PdfSchE:
                 "taxpayer_name_page2": f"{_P2}.f2_1[0]",
                 "taxpayer_ssn_page2":  f"{_P2}.f2_2[0]",
 
-                # ── Part II — Line 28, Row A ────────────────────────────────────
-                # Columns a-f sub-table (name, EIN, entity-type checkboxes)
-                "sch_e_part_ii_row_a_name":
-                    f"{_T28AF}.RowA[0].f2_3[0]",
-                "sch_e_part_ii_row_a_ein":
-                    f"{_T28AF}.RowA[0].f2_4[0]",
-                # Entity-type checkboxes: P=partnership, S=s_corp
-                "sch_e_part_ii_row_a_entity_type_partnership":
-                    f"{_T28AF}.RowA[0].c2_2[0]",
-                "sch_e_part_ii_row_a_entity_type_s_corp":
-                    f"{_T28AF}.RowA[0].c2_3[0]",
-                # Columns g-k sub-table: passive loss, passive income,
-                # nonpassive loss, [§179 skip], nonpassive income
-                "sch_e_part_ii_row_a_passive_loss":
-                    f"{_T28GK}.RowA[0].f2_15[0]",
-                "sch_e_part_ii_row_a_passive_income":
-                    f"{_T28GK}.RowA[0].f2_16[0]",
-                "sch_e_part_ii_row_a_nonpassive_loss":
-                    f"{_T28GK}.RowA[0].f2_17[0]",
-                "sch_e_part_ii_row_a_nonpassive_income":
-                    f"{_T28GK}.RowA[0].f2_19[0]",
-
-                # ── Part II — Line 28, Row B ────────────────────────────────────
-                "sch_e_part_ii_row_b_name":
-                    f"{_T28AF}.RowB[0].f2_6[0]",
-                "sch_e_part_ii_row_b_ein":
-                    f"{_T28AF}.RowB[0].f2_7[0]",
-                "sch_e_part_ii_row_b_entity_type_partnership":
-                    f"{_T28AF}.RowB[0].c2_5[0]",
-                "sch_e_part_ii_row_b_entity_type_s_corp":
-                    f"{_T28AF}.RowB[0].c2_6[0]",
-                "sch_e_part_ii_row_b_passive_loss":
-                    f"{_T28GK}.RowB[0].f2_20[0]",
-                "sch_e_part_ii_row_b_passive_income":
-                    f"{_T28GK}.RowB[0].f2_21[0]",
-                "sch_e_part_ii_row_b_nonpassive_loss":
-                    f"{_T28GK}.RowB[0].f2_22[0]",
-                "sch_e_part_ii_row_b_nonpassive_income":
-                    f"{_T28GK}.RowB[0].f2_24[0]",
-
-                # ── Part II — Line 28, Row C ────────────────────────────────────
-                "sch_e_part_ii_row_c_name":
-                    f"{_T28AF}.RowC[0].f2_9[0]",
-                "sch_e_part_ii_row_c_ein":
-                    f"{_T28AF}.RowC[0].f2_10[0]",
-                "sch_e_part_ii_row_c_entity_type_partnership":
-                    f"{_T28AF}.RowC[0].c2_8[0]",
-                "sch_e_part_ii_row_c_entity_type_s_corp":
-                    f"{_T28AF}.RowC[0].c2_9[0]",
-                "sch_e_part_ii_row_c_passive_loss":
-                    f"{_T28GK}.RowC[0].f2_25[0]",
-                "sch_e_part_ii_row_c_passive_income":
-                    f"{_T28GK}.RowC[0].f2_26[0]",
-                "sch_e_part_ii_row_c_nonpassive_loss":
-                    f"{_T28GK}.RowC[0].f2_27[0]",
-                "sch_e_part_ii_row_c_nonpassive_income":
-                    f"{_T28GK}.RowC[0].f2_29[0]",
-
-                # ── Part II — Line 28, Row D ────────────────────────────────────
-                "sch_e_part_ii_row_d_name":
-                    f"{_T28AF}.RowD[0].f2_12[0]",
-                "sch_e_part_ii_row_d_ein":
-                    f"{_T28AF}.RowD[0].f2_13[0]",
-                "sch_e_part_ii_row_d_entity_type_partnership":
-                    f"{_T28AF}.RowD[0].c2_11[0]",
-                "sch_e_part_ii_row_d_entity_type_s_corp":
-                    f"{_T28AF}.RowD[0].c2_12[0]",
-                "sch_e_part_ii_row_d_passive_loss":
-                    f"{_T28GK}.RowD[0].f2_30[0]",
-                "sch_e_part_ii_row_d_passive_income":
-                    f"{_T28GK}.RowD[0].f2_31[0]",
-                "sch_e_part_ii_row_d_nonpassive_loss":
-                    f"{_T28GK}.RowD[0].f2_32[0]",
-                "sch_e_part_ii_row_d_nonpassive_income":
-                    f"{_T28GK}.RowD[0].f2_34[0]",
+                # ── Part II — Line 28, Rows A–D (generated via _row_mapping) ──────
+                **{
+                    k: v
+                    for letter in _ROWS
+                    for k, v in _row_mapping(letter).items()
+                },
 
                 # ── Part II — Line 29 column totals ────────────────────────────
                 # Line 29a row (y≈480): passive-loss(e), passive-income(f),

--- a/tenforty/models.py
+++ b/tenforty/models.py
@@ -317,6 +317,15 @@ class TaxReturnConfig:
         if isinstance(self.filing_status, str):
             self.filing_status = FilingStatus(self.filing_status)
 
+    @property
+    def full_name(self) -> str:
+        """Single source of 'First Last' formatting consumed by every form's
+        PDF-header emission. Stripped at each half so trailing whitespace in
+        one field doesn't leave a stray space when the other is empty."""
+        first = self.first_name.strip()
+        last = self.last_name.strip()
+        return f"{first} {last}".strip()
+
 
 @dataclass
 class ItemizedDeductions:

--- a/tenforty/models.py
+++ b/tenforty/models.py
@@ -147,6 +147,23 @@ class FilingStatus(str, Enum):
     QUALIFYING_WIDOW = "qualifying_widow"
 
 
+class EntityType(str, Enum):
+    """Pass-through entity type carried on ScheduleK1. YAML fixtures yield
+    strings; str-Enum lets them compare equal to their value string and
+    round-trip through a YAML boundary without a custom resolver."""
+    S_CORP = "s_corp"
+    PARTNERSHIP = "partnership"
+    ESTATE_TRUST = "estate_trust"
+
+
+class AccountingMethod(str, Enum):
+    """Entity-level accounting method. Declared now for Sub-plan 2's 1120-S
+    Schedule B; no Pass 1 consumer."""
+    CASH = "cash"
+    ACCRUAL = "accrual"
+    OTHER = "other"
+
+
 @dataclass
 class TaxReturnConfig:
     year: int

--- a/tenforty/models.py
+++ b/tenforty/models.py
@@ -175,7 +175,7 @@ class PayerAmount:
     additions, and any place where income is attributed to a named source.
 
     Replaces the 2-tuple / 2-key-dict {"payer", "amount"} shape that flowed
-    through multiple forms in Plan D."""
+    through multiple forms before typed dataclasses were adopted."""
     payer: str
     amount: float
 
@@ -199,14 +199,12 @@ class K1FanoutActivity:
 
 @dataclass(frozen=True)
 class K1FanoutData:
-    """Typed sidecar result of sch_e_part_ii.compute. Replaces the
-    underscore-prefixed `_k1_fanout` dict that Plan D threaded through
-    upstream. Consumers (sch_b, sch_d, f8995, f8582) read fields by name,
-    not by positional index or string key.
+    """Typed sidecar produced by sch_e_part_ii.compute, carrying K-1-derived
+    additions consumed by downstream form computes (sch_b, sch_d, f8995,
+    f8582). Fields are read by name, not by positional index or string key.
 
-    qualified_dividends_aggregate matches what Plan D called "qualified_dividends_total"
-    in the old sidecar dict — renamed here to match the "aggregate" suffix
-    used by qbi_aggregate for consistency."""
+    qualified_dividends_aggregate is aggregated from K-1s using the same
+    "aggregate" suffix convention as qbi_aggregate for consistency."""
     sch_b_interest_additions: tuple[PayerAmount, ...]
     sch_b_dividend_additions: tuple[PayerAmount, ...]
     sch_d_short_term_additions: tuple[float, ...]
@@ -273,7 +271,7 @@ class TaxReturnConfig:
     # NotImplementedError when state is in the no-income-tax set AND
     # itemizing would apply, preventing silent under/over-deduction.
     acknowledges_sch_a_sales_tax_unsupported: bool | None = None
-    # --- Plan D scope-out attestations (9 unconditional + 1 factual bool) ---
+    # --- K-1 scope-out attestations (9 unconditional + 1 factual bool) ---
     # All are `bool | None = None`; load_scenario raises ValueError if any is
     # left as None. Compute-time gates fire only when the predicate condition
     # is actually met (e.g., a K-1 is present, a nonzero field exists, etc.).
@@ -306,7 +304,7 @@ class TaxReturnConfig:
     # Factual input (not an attestation): drives 1099-G state-refund
     # tax-benefit-rule compute. None at load raises.
     prior_year_itemized: bool | None = None
-    # --- Plan D conditional fields (validated only when sibling is set) ---
+    # --- Conditional fields (validated only when sibling is set) ---
     # Required only when filing_status == MARRIED_SEPARATELY. Per IRC §469(i)(5),
     # MFS filers who lived with a spouse at any time during the year have a
     # $0 Form 8582 special allowance for rental real estate.

--- a/tenforty/models.py
+++ b/tenforty/models.py
@@ -226,6 +226,18 @@ class K1FanoutData:
         )
 
 
+@dataclass(frozen=True)
+class VoluntaryContribution:
+    """A single CA 540 voluntary-contribution line item. Declared in Pass 1
+    for Sub-plan 3's CA540PersonalOverlay; no Pass 1 consumer.
+
+    fund_code follows FTB-defined fund abbreviations (e.g. "WLD" = California
+    Seniors Special Fund; "KID" = Child Victims of Human Trafficking Fund).
+    """
+    fund_code: str
+    amount: float
+
+
 @dataclass
 class TaxReturnConfig:
     year: int

--- a/tenforty/models.py
+++ b/tenforty/models.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import date as _date
 from enum import Enum
-from typing import Literal
 
 
 @dataclass
@@ -77,7 +76,7 @@ class ScheduleK1:
     """
     entity_name: str
     entity_ein: str
-    entity_type: Literal["s_corp", "partnership", "estate_trust"]
+    entity_type: EntityType
     material_participation: bool
     ordinary_business_income: float = 0.0
     net_rental_real_estate: float = 0.0
@@ -95,6 +94,12 @@ class ScheduleK1:
     section_1231_gain: float = 0.0
     section_179_deduction: float = 0.0
     partnership_self_employment_earnings: float = 0.0
+
+    def __post_init__(self) -> None:
+        # YAML loaders yield plain strings; coerce to the typed enum so all
+        # downstream comparisons work against EntityType members, not raw strings.
+        if isinstance(self.entity_type, str):
+            self.entity_type = EntityType(self.entity_type)
 
 
 @dataclass

--- a/tenforty/models.py
+++ b/tenforty/models.py
@@ -164,6 +164,68 @@ class AccountingMethod(str, Enum):
     OTHER = "other"
 
 
+@dataclass(frozen=True)
+class PayerAmount:
+    """A payer-and-amount line item — K-1-derived Sch B interest/dividend
+    additions, and any place where income is attributed to a named source.
+
+    Replaces the 2-tuple / 2-key-dict {"payer", "amount"} shape that flowed
+    through multiple forms in Plan D."""
+    payer: str
+    amount: float
+
+
+@dataclass(frozen=True)
+class K1FanoutActivity:
+    """One passive-activity row for Form 8582 and related passive-loss
+    predicates. Populated by sch_e_part_ii.compute for every K-1 whose
+    material_participation is False.
+
+    Sign convention: income, loss, and prior_carryforward are all positive
+    magnitudes (>= 0). The loss field being nonzero is itself the direction
+    signal — consumers do not negate."""
+    entity_name: str
+    entity_ein: str
+    entity_type: "EntityType"
+    income: float
+    loss: float
+    prior_carryforward: float
+
+
+@dataclass(frozen=True)
+class K1FanoutData:
+    """Typed sidecar result of sch_e_part_ii.compute. Replaces the
+    underscore-prefixed `_k1_fanout` dict that Plan D threaded through
+    upstream. Consumers (sch_b, sch_d, f8995, f8582) read fields by name,
+    not by positional index or string key.
+
+    qualified_dividends_aggregate matches what Plan D called "qualified_dividends_total"
+    in the old sidecar dict — renamed here to match the "aggregate" suffix
+    used by qbi_aggregate for consistency."""
+    sch_b_interest_additions: tuple[PayerAmount, ...]
+    sch_b_dividend_additions: tuple[PayerAmount, ...]
+    sch_d_short_term_additions: tuple[float, ...]
+    sch_d_long_term_additions: tuple[float, ...]
+    qbi_aggregate: float
+    qualified_dividends_aggregate: float
+    passive_activities: tuple[K1FanoutActivity, ...]
+
+    @classmethod
+    def empty(cls) -> "K1FanoutData":
+        """Returned when no K-1s are present so downstream consumers can
+        unconditionally read upstream['k1_fanout'] without guarding every
+        access."""
+        return cls(
+            sch_b_interest_additions=(),
+            sch_b_dividend_additions=(),
+            sch_d_short_term_additions=(),
+            sch_d_long_term_additions=(),
+            qbi_aggregate=0.0,
+            qualified_dividends_aggregate=0.0,
+            passive_activities=(),
+        )
+
+
 @dataclass
 class TaxReturnConfig:
     year: int

--- a/tenforty/oracle/__init__.py
+++ b/tenforty/oracle/__init__.py
@@ -1,5 +1,5 @@
 """XLSX verification oracle.
 
-Engine and flattener move here in Tasks 2 and 3. Diff harness is deferred
-to Plan B (first form with native-Python compute to diff against).
+Provides engine, flattener, and diff harness for verifying native-Python
+compute outputs against XLSX reference workbooks.
 """

--- a/tenforty/oracle/flattener.py
+++ b/tenforty/oracle/flattener.py
@@ -188,7 +188,7 @@ def _flatten_k1s(scenario: Scenario, flat: dict[str, object]) -> None:
     for i, k1 in enumerate(scenario.schedule_k1s):
         if i >= len(_K1_ROW_LETTERS):
             # The >4 case is gated by acknowledges_no_more_than_four_k1s.
-            # Compute-time enforcement (Task 3) raises if ack is False.
+            # acknowledges_no_more_than_four_k1s=False raises at compute time.
             break
         letter = _K1_ROW_LETTERS[i]
         for attr, key in _K1_FIELD_KEYS:

--- a/tenforty/oracle/flattener.py
+++ b/tenforty/oracle/flattener.py
@@ -196,7 +196,7 @@ def _flatten_k1s(scenario: Scenario, flat: dict[str, object]) -> None:
             if value:
                 flat[f"k1_{letter}_{key}"] = value
         # Entity-type checkbox (mutually exclusive):
-        flat[f"k1_{letter}_entity_type_{k1.entity_type}"] = "X"
+        flat[f"k1_{letter}_entity_type_{k1.entity_type.value}"] = "X"
 
         # Aggregate K-1 income fields into the passive/nonpassive columns
         # that Sch E Part II expects (columns g-k on the form). Ordinary

--- a/tenforty/orchestrator.py
+++ b/tenforty/orchestrator.py
@@ -29,6 +29,7 @@ from tenforty.mappings.pdf_8959 import Pdf8959
 from tenforty.mappings.pdf_f8995 import PdfF8995
 from tenforty.mappings.pdf_f8582 import PdfF8582
 from tenforty.models import FilingStatus, K1FanoutData, Scenario
+from tenforty.types import UpstreamState
 
 _PDFS_ROOT = Path(__file__).parent.parent / "pdfs"
 
@@ -107,6 +108,19 @@ class ReturnOrchestrator:
         year = scenario.config.year
         filler = PdfFiller()
 
+        # Hoist sch_e_part_ii.compute to run at most once per emit_pdfs call.
+        # All downstream consumers (sch_b, sch_d, sch_e, f8995, f8582) share
+        # a single fanout result rather than each recomputing from scratch —
+        # keeping the K-1 fanout computation deterministic and avoiding
+        # redundant spreadsheet evaluation.
+        if self._should_emit_sch_e_part_ii(scenario):
+            part_ii_fields, k1_fanout = form_sch_e_part_ii.compute(scenario, upstream={})
+        else:
+            part_ii_fields = {}
+            k1_fanout = K1FanoutData.empty()
+
+        upstream: UpstreamState = {"f1040": results, "k1_fanout": k1_fanout}
+
         f1040_template = _PDFS_ROOT / "federal" / str(year) / "f1040.pdf"
         # results is already PDF-ready (forms.f1040.compute produced it,
         # including the 25d sum). No translator, no patch needed.
@@ -120,7 +134,7 @@ class ReturnOrchestrator:
 
         f4868_template = _PDFS_ROOT / "federal" / str(year) / "f4868.pdf"
         out_4868 = output_dir / f"f4868_{year}.pdf"
-        f4868_values = form_4868.compute(scenario, upstream={"f1040": results})
+        f4868_values = form_4868.compute(scenario, upstream=upstream)
         filler.fill(
             template_path=f4868_template,
             output_path=out_4868,
@@ -133,13 +147,7 @@ class ReturnOrchestrator:
         if self._should_emit_sch_b(scenario, results):
             sch_b_template = _PDFS_ROOT / "federal" / str(year) / "f1040sb.pdf"
             out_sch_b = output_dir / f"f1040sb_{year}.pdf"
-            sch_b_upstream: dict[str, dict] = {"f1040": results}
-            if self._should_emit_sch_e_part_ii(scenario):
-                _part_ii_fields, _fanout = form_sch_e_part_ii.compute(scenario, upstream={})
-                sch_b_upstream["k1_fanout"] = _fanout
-            sch_b_values = form_sch_b.compute(
-                scenario, upstream=sch_b_upstream,
-            )
+            sch_b_values = form_sch_b.compute(scenario, upstream=upstream)
             flat_values = _flatten_sch_b_rows(sch_b_values)
             filler.fill(
                 template_path=sch_b_template,
@@ -152,13 +160,7 @@ class ReturnOrchestrator:
         if self._should_emit_sch_d(scenario):
             sch_d_template = _PDFS_ROOT / "federal" / str(year) / "f1040sd.pdf"
             out_sch_d = output_dir / f"f1040sd_{year}.pdf"
-            sch_d_upstream: dict[str, dict] = {"f1040": results}
-            if self._should_emit_sch_e_part_ii(scenario):
-                _part_ii_fields, _fanout = form_sch_e_part_ii.compute(scenario, upstream={})
-                sch_d_upstream["k1_fanout"] = _fanout
-            sch_d_values = form_sch_d.compute(
-                scenario, upstream=sch_d_upstream,
-            )
+            sch_d_values = form_sch_d.compute(scenario, upstream=upstream)
             filler.fill_with_repeaters(
                 template_path=sch_d_template,
                 output_path=out_sch_d,
@@ -171,13 +173,7 @@ class ReturnOrchestrator:
         if self._should_emit_sch_e(scenario):
             sch_e_template = _PDFS_ROOT / "federal" / str(year) / "f1040se.pdf"
             out_sch_e = output_dir / f"f1040se_{year}.pdf"
-            part_i = form_sch_e.compute(scenario, upstream={"f1040": results})
-            part_ii_fields: dict = {}
-            part_ii_fanout = K1FanoutData.empty()
-            if self._should_emit_sch_e_part_ii(scenario):
-                part_ii_fields, part_ii_fanout = form_sch_e_part_ii.compute(
-                    scenario, upstream={},
-                )
+            part_i = form_sch_e.compute(scenario, upstream=upstream)
             # Merge: Part I scalars win for shared keys (e.g. taxpayer_name).
             merged = {
                 **part_i,
@@ -199,9 +195,7 @@ class ReturnOrchestrator:
         if self._should_emit_sch_a(scenario, {"f1040": results}):
             sch_a_template = _PDFS_ROOT / "federal" / str(year) / "f1040sa.pdf"
             out_sch_a = output_dir / f"f1040sa_{year}.pdf"
-            sch_a_values = form_sch_a.compute(
-                scenario, upstream={"f1040": results},
-            )
+            sch_a_values = form_sch_a.compute(scenario, upstream=upstream)
             filler.fill_with_repeaters(
                 template_path=sch_a_template,
                 output_path=out_sch_a,
@@ -214,7 +208,7 @@ class ReturnOrchestrator:
             sch_1_template = _PDFS_ROOT / "federal" / str(year) / "f1040s1.pdf"
             out_sch_1 = output_dir / f"f1040s1_{year}.pdf"
             sch_1_values = form_sch_1.compute(
-                scenario, upstream={"sch_e": sch_e_values, "f1040": results},
+                scenario, upstream={**upstream, "sch_e": sch_e_values},
             )
             filler.fill_with_repeaters(
                 template_path=sch_1_template,
@@ -227,7 +221,7 @@ class ReturnOrchestrator:
         if self._should_emit_4562(scenario, {"f1040": results}):
             f4562_template = _PDFS_ROOT / "federal" / str(year) / "f4562.pdf"
             out_4562 = output_dir / f"f4562_{year}.pdf"
-            f4562_values = form_4562.compute(scenario, upstream={})
+            f4562_values = form_4562.compute(scenario, upstream=upstream)
             filler.fill_with_repeaters(
                 template_path=f4562_template,
                 output_path=out_4562,
@@ -239,9 +233,7 @@ class ReturnOrchestrator:
         if self._should_emit_8959(scenario, {"f1040": results}):
             f8959_template = _PDFS_ROOT / "federal" / str(year) / "f8959.pdf"
             out_8959 = output_dir / f"f8959_{year}.pdf"
-            f8959_values = form_8959.compute(
-                scenario, upstream={"f1040": results},
-            )
+            f8959_values = form_8959.compute(scenario, upstream=upstream)
             filler.fill(
                 template_path=f8959_template,
                 output_path=out_8959,
@@ -253,11 +245,7 @@ class ReturnOrchestrator:
         if self._should_emit_8995(scenario):
             f8995_template = _PDFS_ROOT / "federal" / str(year) / "f8995.pdf"
             out_8995 = output_dir / f"f8995_{year}.pdf"
-            _part_ii_fields, _fanout = form_sch_e_part_ii.compute(scenario, upstream={})
-            f8995_values = form_f8995.compute(scenario, upstream={
-                "f1040": results,
-                "k1_fanout": _fanout,
-            })
+            f8995_values = form_f8995.compute(scenario, upstream=upstream)
             filler.fill(
                 template_path=f8995_template,
                 output_path=out_8995,
@@ -266,17 +254,17 @@ class ReturnOrchestrator:
             )
             emitted["f8995"] = out_8995
 
-        if self._should_emit_8582(scenario):
+        if self._should_emit_8582(scenario, upstream):
             f8582_template = _PDFS_ROOT / "federal" / str(year) / "f8582.pdf"
             out_8582 = output_dir / f"f8582_{year}.pdf"
-            # Reuse sch_e_values if already computed above; otherwise compute now.
+            # Reuse sch_e_values if already computed above; otherwise compute
+            # Part I now so 8582 has rental loss context even when Sch E
+            # wasn't emitted (e.g. only passive K-1 activity, no rental property).
             if not sch_e_values:
-                sch_e_values = form_sch_e.compute(scenario, upstream={"f1040": results})
-            _part_ii_fields, _fanout = form_sch_e_part_ii.compute(scenario, upstream={})
+                sch_e_values = form_sch_e.compute(scenario, upstream=upstream)
             f8582_values = form_f8582.compute(scenario, upstream={
-                "f1040": results,
+                **upstream,
                 "sch_e": sch_e_values,
-                "k1_fanout": _fanout,
             })
             filler.fill(
                 template_path=f8582_template,
@@ -356,8 +344,21 @@ class ReturnOrchestrator:
         """Emit Form 8995 whenever any K-1 carries QBI."""
         return any(k1.qbi_amount for k1 in scenario.schedule_k1s)
 
-    def _should_emit_8582(self, scenario: Scenario) -> bool:
-        """Emit 8582 whenever any passive loss is present or carried forward."""
+    def _should_emit_8582(
+        self,
+        scenario: Scenario,
+        upstream: UpstreamState,
+    ) -> bool:
+        """Emit 8582 whenever any passive loss is present or carried forward.
+
+        The `upstream` parameter is accepted here so the caller wiring (Task 8)
+        lands in one commit without a body rewrite. Task 9 (SP1-M4) rewrites
+        this body to read upstream["k1_fanout"].passive_activities instead of
+        re-iterating scenario.schedule_k1s — keeping the gate consistent with
+        the already-computed fanout rather than duplicating the passive-activity
+        classification logic.
+        """
+        del upstream  # Task 9 replaces this body; upstream is not yet consumed
         has_passive_k1_loss = any(
             k1.net_rental_real_estate < 0 or k1.other_net_rental < 0 or
             k1.ordinary_business_income < 0 or k1.prior_year_passive_loss_carryforward

--- a/tenforty/orchestrator.py
+++ b/tenforty/orchestrator.py
@@ -345,26 +345,17 @@ class ReturnOrchestrator:
         return any(k1.qbi_amount for k1 in scenario.schedule_k1s)
 
     def _should_emit_8582(
-        self,
-        scenario: Scenario,
-        upstream: UpstreamState,
+        self, scenario: Scenario, upstream: UpstreamState,
     ) -> bool:
-        """Emit 8582 whenever any passive loss is present or carried forward.
-
-        The `upstream` parameter is accepted here so the caller wiring (Task 8)
-        lands in one commit without a body rewrite. Task 9 (SP1-M4) rewrites
-        this body to read upstream["k1_fanout"].passive_activities instead of
-        re-iterating scenario.schedule_k1s — keeping the gate consistent with
-        the already-computed fanout rather than duplicating the passive-activity
-        classification logic.
-        """
-        del upstream  # Task 9 replaces this body; upstream is not yet consumed
-        has_passive_k1_loss = any(
-            k1.net_rental_real_estate < 0 or k1.other_net_rental < 0 or
-            k1.ordinary_business_income < 0 or k1.prior_year_passive_loss_carryforward
-            for k1 in scenario.schedule_k1s if not k1.material_participation
-        )
-        return has_passive_k1_loss or form_sch_e.has_any_net_loss(scenario)
+        """Emit 8582 when any passive activity has a loss or carryforward,
+        OR when any Sch E Part I rental runs a net loss. Reads the typed
+        K1FanoutData sidecar — no re-classification of per-K-1 fields."""
+        fanout = upstream["k1_fanout"]
+        if any(
+            a.loss or a.prior_carryforward for a in fanout.passive_activities
+        ):
+            return True
+        return form_sch_e.has_any_net_loss(scenario)
 
     def _should_emit_8959(self, scenario: Scenario, results: dict) -> bool:
         """Emit 8959 only when the oracle says it's required (F8959_Reqd).

--- a/tenforty/orchestrator.py
+++ b/tenforty/orchestrator.py
@@ -28,7 +28,7 @@ from tenforty.mappings.pdf_4562 import Pdf4562
 from tenforty.mappings.pdf_8959 import Pdf8959
 from tenforty.mappings.pdf_f8995 import PdfF8995
 from tenforty.mappings.pdf_f8582 import PdfF8582
-from tenforty.models import FilingStatus, Scenario
+from tenforty.models import FilingStatus, K1FanoutData, Scenario
 
 _PDFS_ROOT = Path(__file__).parent.parent / "pdfs"
 
@@ -135,8 +135,8 @@ class ReturnOrchestrator:
             out_sch_b = output_dir / f"f1040sb_{year}.pdf"
             sch_b_upstream: dict[str, dict] = {"f1040": results}
             if self._should_emit_sch_e_part_ii(scenario):
-                part_ii_for_sch_b = form_sch_e_part_ii.compute(scenario, upstream={})
-                sch_b_upstream["_k1_fanout"] = part_ii_for_sch_b["_k1_fanout"]
+                _part_ii_fields, _fanout = form_sch_e_part_ii.compute(scenario, upstream={})
+                sch_b_upstream["k1_fanout"] = _fanout
             sch_b_values = form_sch_b.compute(
                 scenario, upstream=sch_b_upstream,
             )
@@ -154,8 +154,8 @@ class ReturnOrchestrator:
             out_sch_d = output_dir / f"f1040sd_{year}.pdf"
             sch_d_upstream: dict[str, dict] = {"f1040": results}
             if self._should_emit_sch_e_part_ii(scenario):
-                part_ii_for_sch_d = form_sch_e_part_ii.compute(scenario, upstream={})
-                sch_d_upstream["_k1_fanout"] = part_ii_for_sch_d["_k1_fanout"]
+                _part_ii_fields, _fanout = form_sch_e_part_ii.compute(scenario, upstream={})
+                sch_d_upstream["k1_fanout"] = _fanout
             sch_d_values = form_sch_d.compute(
                 scenario, upstream=sch_d_upstream,
             )
@@ -172,14 +172,16 @@ class ReturnOrchestrator:
             sch_e_template = _PDFS_ROOT / "federal" / str(year) / "f1040se.pdf"
             out_sch_e = output_dir / f"f1040se_{year}.pdf"
             part_i = form_sch_e.compute(scenario, upstream={"f1040": results})
-            part_ii: dict = {}
+            part_ii_fields: dict = {}
+            part_ii_fanout = K1FanoutData.empty()
             if self._should_emit_sch_e_part_ii(scenario):
-                part_ii = form_sch_e_part_ii.compute(scenario, upstream={})
-            # Merge: Part I scalars win for shared keys (e.g. taxpayer_name);
-            # strip _-prefixed sidecar keys (e.g. _k1_fanout) from Part II.
+                part_ii_fields, part_ii_fanout = form_sch_e_part_ii.compute(
+                    scenario, upstream={},
+                )
+            # Merge: Part I scalars win for shared keys (e.g. taxpayer_name).
             merged = {
                 **part_i,
-                **{k: v for k, v in part_ii.items() if not k.startswith("_")},
+                **part_ii_fields,
             }
             # Derive page-2 header fields for the mapping layer without
             # polluting compute outputs with PDF-template structure.
@@ -251,10 +253,10 @@ class ReturnOrchestrator:
         if self._should_emit_8995(scenario):
             f8995_template = _PDFS_ROOT / "federal" / str(year) / "f8995.pdf"
             out_8995 = output_dir / f"f8995_{year}.pdf"
-            part_ii = form_sch_e_part_ii.compute(scenario, upstream={})
+            _part_ii_fields, _fanout = form_sch_e_part_ii.compute(scenario, upstream={})
             f8995_values = form_f8995.compute(scenario, upstream={
                 "f1040": results,
-                "_k1_fanout": part_ii["_k1_fanout"],
+                "k1_fanout": _fanout,
             })
             filler.fill(
                 template_path=f8995_template,
@@ -270,11 +272,11 @@ class ReturnOrchestrator:
             # Reuse sch_e_values if already computed above; otherwise compute now.
             if not sch_e_values:
                 sch_e_values = form_sch_e.compute(scenario, upstream={"f1040": results})
-            part_ii_8582 = form_sch_e_part_ii.compute(scenario, upstream={})
+            _part_ii_fields, _fanout = form_sch_e_part_ii.compute(scenario, upstream={})
             f8582_values = form_f8582.compute(scenario, upstream={
                 "f1040": results,
                 "sch_e": sch_e_values,
-                "_k1_fanout": part_ii_8582["_k1_fanout"],
+                "k1_fanout": _fanout,
             })
             filler.fill(
                 template_path=f8582_template,

--- a/tenforty/scenario.py
+++ b/tenforty/scenario.py
@@ -4,6 +4,7 @@ import yaml
 
 from tenforty.models import (
     DepreciableAsset,
+    EntityType,
     FilingStatus,
     Form1098,
     Form1099B,
@@ -233,7 +234,7 @@ def _validate_schedule_k1s(scenario: Scenario) -> None:
     immediately rather than letting it silently land in the wrong column.
     """
     for k1 in scenario.schedule_k1s:
-        if k1.entity_type == "estate_trust" and k1.ordinary_business_income != 0:
+        if k1.entity_type == EntityType.ESTATE_TRUST and k1.ordinary_business_income != 0:
             raise ValueError(
                 f"K-1 {k1.entity_name!r} has entity_type='estate_trust' but "
                 f"nonzero ordinary_business_income={k1.ordinary_business_income}. "

--- a/tenforty/scenario.py
+++ b/tenforty/scenario.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import yaml
 
+from tenforty.attestations import validate_load_time
 from tenforty.models import (
     DepreciableAsset,
     EntityType,
@@ -32,152 +33,23 @@ _FORM_REGISTRY: dict[str, tuple[type, str]] = {
 
 
 def _validate_scenario_config(cfg: TaxReturnConfig) -> None:
-    """Enforce the scope-out attestations documented in Plan B (GH #11).
+    """Enforce the Plan B + Plan D load-time attestations via
+    tenforty.attestations._ATTESTATIONS. Conditional fields (MFS / prior-year
+    recovery) are validated separately because they depend on other config
+    values, not on a trigger-predicate over the full scenario."""
+    validate_load_time(cfg)
 
-    Both `has_foreign_accounts` and `acknowledges_form_8949_unsupported` are
-    required — scenarios MUST declare them explicitly as True or False.
-    Additionally, `has_foreign_accounts=True` raises NotImplementedError
-    immediately because Schedule B Part III / FBAR is not supported in v1.
-    The `acknowledges_form_8949_unsupported=True` case is checked later in
-    `forms.sch_d.compute` only if an 8949-required lot is actually encountered.
-    """
-    if cfg.has_foreign_accounts is None:
-        raise ValueError(
-            "Scenario config field `has_foreign_accounts` is required and must be "
-            "either true or false. Schedule B Part III (Foreign Accounts and Trusts) "
-            "is not implemented in tenforty v1; if any foreign financial account "
-            "exists, this return will be INCORRECT and you may be legally required "
-            "to file FinCEN Form 114 (FBAR). You must answer this question "
-            "explicitly in every scenario."
-        )
+    # has_foreign_accounts=True is an immediate NotImplementedError regardless
+    # of trigger predicate — there is no scenario context that makes a foreign
+    # account safe. Keep this eager raise here rather than in the table.
     if cfg.has_foreign_accounts is True:
         raise NotImplementedError(
             "Schedule B Part III / FBAR is not supported in tenforty v1. "
-            "Returns for filers with foreign financial accounts cannot be produced "
-            "by this version; support is tracked as a follow-up."
+            "Returns for filers with foreign financial accounts cannot be "
+            "produced by this version; support is tracked as a follow-up."
         )
 
-    if cfg.acknowledges_sch_a_sales_tax_unsupported is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_sch_a_sales_tax_unsupported` "
-            "is required and must be either true or false. Schedule A line 5a "
-            "offers a state-and-local INCOME TAX or GENERAL SALES TAX "
-            "election; tenforty v1 implements only the income-tax path. For "
-            "filers in no-state-income-tax states (TX, FL, WA, NV, SD, WY, "
-            "AK, TN, NH) the sales-tax election is usually the correct "
-            "choice and v1 cannot produce it. Set `false` if your state "
-            "levies an income tax (the income-tax path is correct for you). "
-            "Set `true` ONLY if you are in a no-income-tax state AND you "
-            "have reviewed the consequences — v1 will then raise "
-            "NotImplementedError from Sch A compute rather than silently "
-            "overstating your deduction with an income-tax figure that is "
-            "$0 or near-$0 in your state."
-        )
-
-    if cfg.acknowledges_form_8949_unsupported is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_form_8949_unsupported` is required "
-            "and must be either true or false. Form 8949 is not implemented in "
-            "tenforty v1. Lots with uncovered basis, basis adjustments, or "
-            "wash-sale reporting legally require Form 8949. Set `false` if all "
-            "1099-B lots are covered-basis with no adjustments (Sch D summary "
-            "path applies and the return is complete). Set `true` ONLY if you "
-            "have reviewed any 8949-required lots and accept that they will be "
-            "DROPPED from Sch D totals (a warning is logged per dropped lot so "
-            "you can reconcile manually); your return will be INCOMPLETE for "
-            "those lots until 8949 support lands."
-        )
-
-    # --- Plan D unconditional scope-out attestations (9) + prior_year_itemized ---
-    if cfg.acknowledges_qbi_below_threshold is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_qbi_below_threshold` is "
-            "required and must be either true or false. Form 8995-A (full "
-            "QBI) is not implemented in tenforty v1; if a K-1 carries QBI "
-            "and taxable income exceeds the Rev. Proc. 2024-40 threshold "
-            "(~$197,300 single / $394,600 MFJ), compute will raise "
-            "NotImplementedError."
-        )
-    if cfg.acknowledges_unlimited_at_risk is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_unlimited_at_risk` is "
-            "required and must be either true or false. Form 6198 (at-risk "
-            "limitations) is not implemented in tenforty v1; compute will "
-            "raise NotImplementedError at Sch E Part II time if any K-1 is "
-            "present and this attestation is False."
-        )
-    if cfg.basis_tracked_externally is None:
-        raise ValueError(
-            "Scenario config field `basis_tracked_externally` is required "
-            "and must be either true or false. Shareholder/partner basis "
-            "worksheets (Form 7203 for S-corps, partner basis worksheet "
-            "for partnerships) are not implemented in tenforty v1; compute "
-            "will raise NotImplementedError at Sch E Part II time if any "
-            "K-1 is present and this attestation is False."
-        )
-    if cfg.acknowledges_no_partnership_se_earnings is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_no_partnership_se_earnings` "
-            "is required and must be either true or false. Schedule SE is "
-            "not implemented in tenforty v1; compute will raise "
-            "NotImplementedError if a partnership K-1 carries nonzero "
-            "partnership_self_employment_earnings and this attestation is "
-            "False."
-        )
-    if cfg.acknowledges_no_section_1231_gain is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_no_section_1231_gain` is "
-            "required and must be either true or false. Form 4797 (sales "
-            "of business property) is not implemented in tenforty v1; "
-            "compute will raise NotImplementedError if any K-1 carries "
-            "nonzero section_1231_gain and this attestation is False."
-        )
-    if cfg.acknowledges_no_more_than_four_k1s is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_no_more_than_four_k1s` is "
-            "required and must be either true or false. Schedule E Part II "
-            "continuation sheets (for more than 4 K-1s) are not "
-            "implemented in tenforty v1; compute will raise "
-            "NotImplementedError if more than 4 K-1s are present and this "
-            "attestation is False."
-        )
-    if cfg.acknowledges_no_k1_credits is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_no_k1_credits` is "
-            "required and must be either true or false. K-1 box 13 "
-            "(partnership) and box 15 (S-corp) credits are not "
-            "implemented in tenforty v1; compute will raise "
-            "NotImplementedError if this attestation is False and any K-1 "
-            "is present."
-        )
-    if cfg.acknowledges_no_section_179 is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_no_section_179` is "
-            "required and must be either true or false. The Section 179 "
-            "deduction (Form 4562 Part I) flowing through from K-1s is "
-            "not implemented in tenforty v1; compute will raise "
-            "NotImplementedError if any K-1 carries nonzero "
-            "section_179_deduction and this attestation is False."
-        )
-    if cfg.acknowledges_no_estate_trust_k1 is None:
-        raise ValueError(
-            "Scenario config field `acknowledges_no_estate_trust_k1` is "
-            "required and must be either true or false. Schedule E Part "
-            "III (estate and trust K-1 income) is not implemented in "
-            "tenforty v1; compute will raise NotImplementedError if any "
-            "K-1 has entity_type == 'estate_trust'. Declare this "
-            "attestation even when no estate/trust K-1 is present."
-        )
-    if cfg.prior_year_itemized is None:
-        raise ValueError(
-            "Scenario config field `prior_year_itemized` is required and "
-            "must be either true or false. It drives the 1099-G state-tax-"
-            "refund tax-benefit-rule on Schedule 1 line 1: if the prior "
-            "year used the standard deduction, the refund is not taxable; "
-            "if itemized, it is taxable up to the recovery limit."
-        )
-
-    # --- Plan D conditional fields (validated only when sibling says yes) ---
+    # Conditional fields — sibling-dependent, not table-driven.
     if cfg.filing_status == FilingStatus.MARRIED_SEPARATELY:
         if cfg.mfs_lived_with_spouse_any_time is None:
             raise ValueError(

--- a/tenforty/scenario.py
+++ b/tenforty/scenario.py
@@ -33,7 +33,7 @@ _FORM_REGISTRY: dict[str, tuple[type, str]] = {
 
 
 def _validate_scenario_config(cfg: TaxReturnConfig) -> None:
-    """Enforce the Plan B + Plan D load-time attestations via
+    """Enforce the load-time attestations via
     tenforty.attestations._ATTESTATIONS. Conditional fields (MFS / prior-year
     recovery) are validated separately because they depend on other config
     values, not on a trigger-predicate over the full scenario."""

--- a/tenforty/types.py
+++ b/tenforty/types.py
@@ -1,0 +1,29 @@
+"""Typed state threaded through a compute stage.
+
+UpstreamState is the dict shape passed between form.compute() calls within
+one compute stage. total=False — unset keys raise KeyError, not return None,
+so misspellings fail loudly rather than silently.
+
+Pass 1 populates only the federal-personal-stage keys that exist today.
+Sub-plans 1-4 (issue #20) extend this with f8949, f1120s, sch_k_1120s,
+f540, sch_ca_540, sch_d_540, sch_p_540, f100s, f3804, sch_k_100s.
+"""
+
+from typing import Any, TypedDict
+
+from tenforty.models import K1FanoutData
+
+
+class UpstreamState(TypedDict, total=False):
+    f1040: dict[str, Any]
+    sch_1: dict[str, Any]
+    sch_a: dict[str, Any]
+    sch_b: dict[str, Any]
+    sch_d: dict[str, Any]
+    sch_e: dict[str, Any]
+    sch_e_part_ii: dict[str, Any]
+    f4562: dict[str, Any]
+    f8582: dict[str, Any]
+    f8959: dict[str, Any]
+    f8995: dict[str, Any]
+    k1_fanout: K1FanoutData

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -31,6 +31,34 @@ needs_pdf = unittest.skipUnless(
 )
 
 
+def plan_d_attestation_defaults() -> dict[str, bool]:
+    """Return a dict mapping every Plan B + Plan D attestation field to a
+    default value suitable for a bare in-memory test scenario.
+
+    Task 11 sets every field to False, matching the legacy `make_simple_scenario`
+    posture verbatim so introducing the data-driven table does NOT change
+    behavior for any existing test. Task 12 migrates individual defaults
+    where the spec's target posture for K-1-bearing scenarios differs
+    (`acknowledges_unlimited_at_risk`, `basis_tracked_externally`,
+    `acknowledges_no_k1_credits`). Tests that relied on the all-False posture
+    will be updated there, not here."""
+    return {
+        "has_foreign_accounts": False,
+        "acknowledges_form_8949_unsupported": False,
+        "acknowledges_sch_a_sales_tax_unsupported": False,
+        "acknowledges_qbi_below_threshold": False,
+        "acknowledges_unlimited_at_risk": False,
+        "basis_tracked_externally": False,
+        "acknowledges_no_partnership_se_earnings": False,
+        "acknowledges_no_section_1231_gain": False,
+        "acknowledges_no_more_than_four_k1s": False,
+        "acknowledges_no_k1_credits": False,
+        "acknowledges_no_section_179": False,
+        "acknowledges_no_estate_trust_k1": False,
+        "prior_year_itemized": False,
+    }
+
+
 def make_simple_scenario() -> Scenario:
     """Create a simple single-filer scenario for tests that need a Scenario instance.
 
@@ -45,19 +73,7 @@ def make_simple_scenario() -> Scenario:
             filing_status="single",
             birthdate="1990-06-15",
             state="CA",
-            has_foreign_accounts=False,
-            acknowledges_form_8949_unsupported=False,
-            acknowledges_sch_a_sales_tax_unsupported=False,
-            acknowledges_qbi_below_threshold=False,
-            acknowledges_unlimited_at_risk=False,
-            basis_tracked_externally=False,
-            acknowledges_no_partnership_se_earnings=False,
-            acknowledges_no_section_1231_gain=False,
-            acknowledges_no_more_than_four_k1s=False,
-            acknowledges_no_k1_credits=False,
-            acknowledges_no_section_179=False,
-            acknowledges_no_estate_trust_k1=False,
-            prior_year_itemized=False,
+            **plan_d_attestation_defaults(),
         ),
         w2s=[
             W2(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -32,28 +32,27 @@ needs_pdf = unittest.skipUnless(
 
 
 def plan_d_attestation_defaults() -> dict[str, bool]:
-    """Return a dict mapping every Plan B + Plan D attestation field to a
-    default value suitable for a bare in-memory test scenario.
+    """Return a dict of all attestation fields pre-set for a K-1-capable
+    in-memory test scenario.
 
-    Three fields default to True because they affirm the spec's target posture
-    for any K-1-bearing scenario (unlimited at-risk amounts, basis tracked
-    externally, no K-1 credits). The other ten fields stay False because their
-    triggers check per-K-1-field values (e.g. `_has_partnership_se_earnings`,
-    `_has_section_1231`, `_more_than_four_k1s`) — an all-False default is safe
-    because the gate only fires if the scenario's K-1s actually carry the
-    triggering field. Tests that need the False value for one of the three
-    migrated fields should set it explicitly on `scenario.config`."""
+    Three fields default to True because they affirm the common test posture:
+    unlimited at-risk amounts, basis tracked externally, and no K-1 credits.
+    The other ten fields stay False because their compute-time gates fire only
+    when the scenario's K-1s actually carry the triggering field value — an
+    all-False default is safe and conservative. Tests that need a different
+    value for one of the three True fields should override it explicitly on
+    `scenario.config`."""
     return {
         "has_foreign_accounts": False,
         "acknowledges_form_8949_unsupported": False,
         "acknowledges_sch_a_sales_tax_unsupported": False,
         "acknowledges_qbi_below_threshold": False,
-        "acknowledges_unlimited_at_risk": True,   # migrated in Task 12
-        "basis_tracked_externally": True,         # migrated in Task 12
+        "acknowledges_unlimited_at_risk": True,
+        "basis_tracked_externally": True,
         "acknowledges_no_partnership_se_earnings": False,
         "acknowledges_no_section_1231_gain": False,
         "acknowledges_no_more_than_four_k1s": False,
-        "acknowledges_no_k1_credits": True,       # migrated in Task 12
+        "acknowledges_no_k1_credits": True,
         "acknowledges_no_section_179": False,
         "acknowledges_no_estate_trust_k1": False,
         "prior_year_itemized": False,
@@ -63,7 +62,7 @@ def plan_d_attestation_defaults() -> dict[str, bool]:
 def make_simple_scenario() -> Scenario:
     """Create a simple single-filer scenario for tests that need a Scenario instance.
 
-    Sets all Plan B and Plan D load-time scope-out attestations to False so
+    Sets all load-time scope-out attestations to False so
     in-memory fixtures mirror the load-time contract enforced on YAML fixtures.
     Also sets `prior_year_itemized=False` (factual) to mean last year took the
     standard deduction, so 1099-G state-refund tax-benefit-rule short-circuits.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -35,24 +35,25 @@ def plan_d_attestation_defaults() -> dict[str, bool]:
     """Return a dict mapping every Plan B + Plan D attestation field to a
     default value suitable for a bare in-memory test scenario.
 
-    Task 11 sets every field to False, matching the legacy `make_simple_scenario`
-    posture verbatim so introducing the data-driven table does NOT change
-    behavior for any existing test. Task 12 migrates individual defaults
-    where the spec's target posture for K-1-bearing scenarios differs
-    (`acknowledges_unlimited_at_risk`, `basis_tracked_externally`,
-    `acknowledges_no_k1_credits`). Tests that relied on the all-False posture
-    will be updated there, not here."""
+    Three fields default to True because they affirm the spec's target posture
+    for any K-1-bearing scenario (unlimited at-risk amounts, basis tracked
+    externally, no K-1 credits). The other ten fields stay False because their
+    triggers check per-K-1-field values (e.g. `_has_partnership_se_earnings`,
+    `_has_section_1231`, `_more_than_four_k1s`) — an all-False default is safe
+    because the gate only fires if the scenario's K-1s actually carry the
+    triggering field. Tests that need the False value for one of the three
+    migrated fields should set it explicitly on `scenario.config`."""
     return {
         "has_foreign_accounts": False,
         "acknowledges_form_8949_unsupported": False,
         "acknowledges_sch_a_sales_tax_unsupported": False,
         "acknowledges_qbi_below_threshold": False,
-        "acknowledges_unlimited_at_risk": False,
-        "basis_tracked_externally": False,
+        "acknowledges_unlimited_at_risk": True,   # migrated in Task 12
+        "basis_tracked_externally": True,         # migrated in Task 12
         "acknowledges_no_partnership_se_earnings": False,
         "acknowledges_no_section_1231_gain": False,
         "acknowledges_no_more_than_four_k1s": False,
-        "acknowledges_no_k1_credits": False,
+        "acknowledges_no_k1_credits": True,       # migrated in Task 12
         "acknowledges_no_section_179": False,
         "acknowledges_no_estate_trust_k1": False,
         "prior_year_itemized": False,

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -91,3 +91,56 @@ class TestComputeTimeGate(unittest.TestCase):
         with self.assertRaises(NotImplementedError) as ctx:
             sch_e_part_ii.compute(scenario, upstream={})
         self.assertIn("at_risk", str(ctx.exception).lower())
+
+
+class TestDefaultsAfterMigration(unittest.TestCase):
+    """Task 12 (SP1-M2 part 2) migrates three defaults from False to True so
+    that a bare in-memory test scenario matches the spec's target posture for
+    K-1-bearing returns."""
+
+    def test_unlimited_at_risk_defaults_true(self) -> None:
+        from tests.helpers import plan_d_attestation_defaults
+        self.assertIs(plan_d_attestation_defaults()["acknowledges_unlimited_at_risk"], True)
+
+    def test_basis_tracked_externally_defaults_true(self) -> None:
+        from tests.helpers import plan_d_attestation_defaults
+        self.assertIs(plan_d_attestation_defaults()["basis_tracked_externally"], True)
+
+    def test_acknowledges_no_k1_credits_defaults_true(self) -> None:
+        from tests.helpers import plan_d_attestation_defaults
+        self.assertIs(plan_d_attestation_defaults()["acknowledges_no_k1_credits"], True)
+
+    def test_other_defaults_remain_false(self) -> None:
+        """Only the three K-1-posture fields migrate. Everything else stays
+        all-False — their triggers are more specific (per-K-1-field) so the
+        pessimal default is still safe."""
+        from tests.helpers import plan_d_attestation_defaults
+        d = plan_d_attestation_defaults()
+        for f in (
+            "has_foreign_accounts",
+            "acknowledges_form_8949_unsupported",
+            "acknowledges_sch_a_sales_tax_unsupported",
+            "acknowledges_qbi_below_threshold",
+            "acknowledges_no_partnership_se_earnings",
+            "acknowledges_no_section_1231_gain",
+            "acknowledges_no_more_than_four_k1s",
+            "acknowledges_no_section_179",
+            "acknowledges_no_estate_trust_k1",
+            "prior_year_itemized",
+        ):
+            self.assertIs(d[f], False, f"{f} should default to False")
+
+    def test_make_simple_scenario_with_k1_does_not_raise(self) -> None:
+        """The motivating use case for the migration: constructing a scenario
+        with an S-corp K-1 via make_simple_scenario() should succeed end-to-end
+        now that the three K-1-posture attestations default to True."""
+        from tenforty.forms import sch_e_part_ii
+        from tenforty.models import EntityType, ScheduleK1
+        from tests.helpers import make_simple_scenario
+        scenario = make_simple_scenario()
+        scenario.schedule_k1s = [ScheduleK1(
+            entity_name="X", entity_ein="00-0000000",
+            entity_type=EntityType.S_CORP, material_participation=True,
+            ordinary_business_income=1000.0,
+        )]
+        sch_e_part_ii.compute(scenario, upstream={})

--- a/tests/test_attestations.py
+++ b/tests/test_attestations.py
@@ -1,0 +1,93 @@
+"""Tests for the data-driven _ATTESTATIONS table."""
+
+import unittest
+
+from tenforty.attestations import Attestation, _ATTESTATIONS
+
+
+class TestAttestationsTable(unittest.TestCase):
+    def test_table_is_non_empty(self) -> None:
+        self.assertGreaterEqual(len(_ATTESTATIONS), 13)
+
+    def test_each_entry_has_required_fields(self) -> None:
+        for a in _ATTESTATIONS:
+            self.assertIsInstance(a, Attestation)
+            self.assertTrue(a.field)
+            self.assertTrue(callable(a.triggered_when))
+            self.assertTrue(a.load_error)
+            # compute_error is optional for pure load-time gates
+            # (has_foreign_accounts raises NotImplementedError
+            # immediately on True, so no compute-time gate needed).
+
+    def test_covers_plan_b_and_plan_d_fields(self) -> None:
+        fields = {a.field for a in _ATTESTATIONS}
+        expected = {
+            "has_foreign_accounts",
+            "acknowledges_form_8949_unsupported",
+            "acknowledges_sch_a_sales_tax_unsupported",
+            "acknowledges_qbi_below_threshold",
+            "acknowledges_unlimited_at_risk",
+            "basis_tracked_externally",
+            "acknowledges_no_partnership_se_earnings",
+            "acknowledges_no_section_1231_gain",
+            "acknowledges_no_more_than_four_k1s",
+            "acknowledges_no_k1_credits",
+            "acknowledges_no_section_179",
+            "acknowledges_no_estate_trust_k1",
+            "prior_year_itemized",
+        }
+        self.assertEqual(expected, fields)
+
+
+class TestLoadTimeValidation(unittest.TestCase):
+    def test_missing_has_foreign_accounts_raises(self) -> None:
+        from tenforty.models import TaxReturnConfig
+        from tenforty.scenario import _validate_scenario_config
+        cfg = TaxReturnConfig(
+            year=2025, filing_status="single", birthdate="1990-06-15",
+            state="CA",
+        )
+        with self.assertRaises(ValueError) as ctx:
+            _validate_scenario_config(cfg)
+        self.assertIn("has_foreign_accounts", str(ctx.exception))
+
+    def test_all_answered_passes(self) -> None:
+        from tenforty.models import TaxReturnConfig
+        from tenforty.scenario import _validate_scenario_config
+        kw = dict(
+            year=2025, filing_status="single", birthdate="1990-06-15",
+            state="CA", has_foreign_accounts=False,
+            acknowledges_form_8949_unsupported=False,
+            acknowledges_sch_a_sales_tax_unsupported=False,
+            acknowledges_qbi_below_threshold=False,
+            acknowledges_unlimited_at_risk=False,
+            basis_tracked_externally=False,
+            acknowledges_no_partnership_se_earnings=False,
+            acknowledges_no_section_1231_gain=False,
+            acknowledges_no_more_than_four_k1s=False,
+            acknowledges_no_k1_credits=False,
+            acknowledges_no_section_179=False,
+            acknowledges_no_estate_trust_k1=False,
+            prior_year_itemized=False,
+        )
+        cfg = TaxReturnConfig(**kw)
+        _validate_scenario_config(cfg)  # no raise
+
+
+class TestComputeTimeGate(unittest.TestCase):
+    def test_k1_present_but_unlimited_at_risk_false_raises(self) -> None:
+        from tenforty.forms import sch_e_part_ii
+        from tenforty.models import EntityType, ScheduleK1
+        from tests.helpers import make_simple_scenario
+        scenario = make_simple_scenario()
+        scenario.config.acknowledges_unlimited_at_risk = False
+        scenario.config.basis_tracked_externally = True
+        scenario.config.acknowledges_no_k1_credits = True
+        scenario.schedule_k1s = [ScheduleK1(
+            entity_name="X", entity_ein="00-0000000",
+            entity_type=EntityType.S_CORP, material_participation=True,
+            ordinary_business_income=1000.0,
+        )]
+        with self.assertRaises(NotImplementedError) as ctx:
+            sch_e_part_ii.compute(scenario, upstream={})
+        self.assertIn("at_risk", str(ctx.exception).lower())

--- a/tests/test_f4868_compute.py
+++ b/tests/test_f4868_compute.py
@@ -6,8 +6,7 @@ from tenforty.forms.f4868 import compute, compute_balance_due
 
 def _scenario(**overrides):
     config = SimpleNamespace(
-        first_name="Ada",
-        last_name="Lovelace",
+        full_name="Ada Lovelace",
         ssn="000-45-6789",
         spouse_ssn="",
         address="1 Analytical Engine Way",

--- a/tests/test_f8582_compute.py
+++ b/tests/test_f8582_compute.py
@@ -22,12 +22,12 @@ def _passive_k1_loss(name: str, loss: float, carryforward: float = 0.0) -> Sched
 
 
 def _run(s, magi):
-    part_ii = form_sch_e_part_ii.compute(s, upstream={})
+    _, fanout = form_sch_e_part_ii.compute(s, upstream={})
     sch_e = form_sch_e.compute(s, upstream={"f1040": {}})
     return f8582.compute(s, upstream={
         "f1040": {"magi": magi},
         "sch_e": sch_e,
-        "_k1_fanout": part_ii["_k1_fanout"],
+        "k1_fanout": fanout,
     })
 
 

--- a/tests/test_f8582_oracle.py
+++ b/tests/test_f8582_oracle.py
@@ -37,11 +37,11 @@ class F8582OracleTests(unittest.TestCase):
             f1040 = orch.compute_federal(s)
 
         sch_e = form_sch_e.compute(s, upstream={"f1040": f1040})
-        part_ii = form_sch_e_part_ii.compute(s, upstream={})
+        _part_ii_fields, fanout = form_sch_e_part_ii.compute(s, upstream={})
         native = form_f8582.compute(s, upstream={
             "f1040": f1040,
             "sch_e": sch_e,
-            "_k1_fanout": part_ii["_k1_fanout"],
+            "k1_fanout": fanout,
         })
         self.assertEqual(
             native["f8582_line_11_allowed_loss"],

--- a/tests/test_f8995_compute.py
+++ b/tests/test_f8995_compute.py
@@ -3,7 +3,7 @@
 import unittest
 
 from tenforty.forms import f8995
-from tenforty.models import ScheduleK1
+from tenforty.models import K1FanoutData, ScheduleK1
 
 from tests.helpers import make_k1_scenario
 
@@ -18,15 +18,21 @@ def _scenario_with_qbi(qbi: float = 20_000.0, taxable_income: float = 100_000.0,
         material_participation=True,
         qbi_amount=qbi,
     )]
+    fanout = K1FanoutData(
+        sch_b_interest_additions=(),
+        sch_b_dividend_additions=(),
+        sch_d_short_term_additions=(),
+        sch_d_long_term_additions=(),
+        qbi_aggregate=qbi,
+        qualified_dividends_aggregate=0.0,
+        passive_activities=(),
+    )
     upstream = {
         "f1040": {
             "taxable_income_before_qbi_deduction": taxable_income,
             "net_capital_gain": net_cap_gain,
         },
-        "_k1_fanout": {
-            "qbi_total": qbi,
-            "qualified_dividends_total": 0.0,
-        },
+        "k1_fanout": fanout,
     }
     return s, upstream
 

--- a/tests/test_f8995_oracle.py
+++ b/tests/test_f8995_oracle.py
@@ -34,10 +34,10 @@ class F8995OracleTests(unittest.TestCase):
             )
             f1040 = orch.compute_federal(s)
 
-        sch_e_part_ii = form_sch_e_part_ii.compute(s, upstream={})
+        _sch_e_part_ii_fields, fanout = form_sch_e_part_ii.compute(s, upstream={})
         upstream = {
             "f1040": f1040,
-            "_k1_fanout": sch_e_part_ii["_k1_fanout"],
+            "k1_fanout": fanout,
         }
         native = form_f8995.compute(s, upstream=upstream)
         self.assertEqual(

--- a/tests/test_k1_fanout_per_entity_type.py
+++ b/tests/test_k1_fanout_per_entity_type.py
@@ -40,22 +40,22 @@ class K1SupportedEntityFanoutTests(unittest.TestCase):
         k1 = _supported_k1(entity_type)
         s = make_k1_scenario()
         s.schedule_k1s = [k1]
-        part_ii = form_sch_e_part_ii.compute(s, upstream={})
+        part_ii_fields, fanout = form_sch_e_part_ii.compute(s, upstream={})
         sch_b = form_sch_b.compute(
-            s, upstream={"_k1_fanout": part_ii["_k1_fanout"], "f1040": {}},
+            s, upstream={"k1_fanout": fanout, "f1040": {}},
         )
         sch_d = form_sch_d.compute(
-            s, upstream={"_k1_fanout": part_ii["_k1_fanout"]},
+            s, upstream={"k1_fanout": fanout},
         )
 
         expected = k1_reference.k1_to_expected_outputs(k1)
         row = expected["sch_e_part_ii_row"]
         self.assertEqual(
-            part_ii["sch_e_part_ii_row_a_nonpassive_income"],
+            part_ii_fields["sch_e_part_ii_row_a_nonpassive_income"],
             round(row["nonpassive_income"]),
         )
         self.assertEqual(
-            part_ii["sch_e_part_ii_row_a_passive_income"],
+            part_ii_fields["sch_e_part_ii_row_a_passive_income"],
             round(row["passive_income"]),
         )
 
@@ -73,16 +73,16 @@ class K1SupportedEntityFanoutTests(unittest.TestCase):
 
         sch_d_adds = expected["sch_d_additions"]
         self.assertEqual(
-            round(part_ii["_k1_fanout"]["short_term_cap_gain_from_k1s"]),
+            round(sum(fanout.sch_d_short_term_additions)),
             round(sch_d_adds["short_term"]),
         )
         self.assertEqual(
-            round(part_ii["_k1_fanout"]["long_term_cap_gain_from_k1s"]),
+            round(sum(fanout.sch_d_long_term_additions)),
             round(sch_d_adds["long_term"]),
         )
 
         self.assertEqual(
-            round(part_ii["_k1_fanout"]["qbi_total"]),
+            round(fanout.qbi_aggregate),
             round(expected["qbi_amount"]),
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -485,3 +485,17 @@ class TestK1FanoutData(unittest.TestCase):
         )
         self.assertEqual(len(fanout.passive_activities), 1)
         self.assertEqual(fanout.sch_b_interest_additions[0].payer, "X")
+
+
+class TestVoluntaryContribution(unittest.TestCase):
+    def test_fields(self) -> None:
+        from tenforty.models import VoluntaryContribution
+        vc = VoluntaryContribution(fund_code="WLD", amount=10.0)
+        self.assertEqual(vc.fund_code, "WLD")
+        self.assertEqual(vc.amount, 10.0)
+
+    def test_frozen(self) -> None:
+        from tenforty.models import VoluntaryContribution
+        vc = VoluntaryContribution(fund_code="WLD", amount=10.0)
+        with self.assertRaises(Exception):  # FrozenInstanceError
+            vc.amount = 20.0  # type: ignore[misc]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -406,3 +406,82 @@ class TestAccountingMethod(unittest.TestCase):
     def test_is_str_subclass(self) -> None:
         from tenforty.models import AccountingMethod
         self.assertIsInstance(AccountingMethod.CASH, str)
+
+
+class TestPayerAmount(unittest.TestCase):
+    def test_fields(self) -> None:
+        from tenforty.models import PayerAmount
+        pa = PayerAmount(payer="Fake S-Corp Inc", amount=150.0)
+        self.assertEqual(pa.payer, "Fake S-Corp Inc")
+        self.assertEqual(pa.amount, 150.0)
+
+    def test_frozen(self) -> None:
+        from tenforty.models import PayerAmount
+        pa = PayerAmount(payer="X", amount=1.0)
+        with self.assertRaises(Exception):
+            pa.amount = 2.0  # type: ignore[misc]
+
+
+class TestK1FanoutActivity(unittest.TestCase):
+    def test_fields(self) -> None:
+        from tenforty.models import EntityType, K1FanoutActivity
+        a = K1FanoutActivity(
+            entity_name="Fake S-Corp Inc",
+            entity_ein="00-0000000",
+            entity_type=EntityType.S_CORP,
+            income=500.0,
+            loss=0.0,
+            prior_carryforward=200.0,
+        )
+        self.assertEqual(a.entity_name, "Fake S-Corp Inc")
+        self.assertEqual(a.entity_type, EntityType.S_CORP)
+        self.assertEqual(a.income, 500.0)
+        self.assertEqual(a.loss, 0.0)
+        self.assertEqual(a.prior_carryforward, 200.0)
+
+    def test_magnitudes_are_positive(self) -> None:
+        """income/loss/prior_carryforward are all positive magnitudes by
+        convention — loss being nonzero is itself the direction signal."""
+        from tenforty.models import EntityType, K1FanoutActivity
+        a = K1FanoutActivity(
+            entity_name="X", entity_ein="00-0000000",
+            entity_type=EntityType.PARTNERSHIP,
+            income=0.0, loss=800.0, prior_carryforward=0.0,
+        )
+        self.assertGreaterEqual(a.loss, 0.0)
+        self.assertGreaterEqual(a.prior_carryforward, 0.0)
+
+
+class TestK1FanoutData(unittest.TestCase):
+    def test_empty_constructor(self) -> None:
+        from tenforty.models import K1FanoutData
+        empty = K1FanoutData.empty()
+        self.assertEqual(empty.sch_b_interest_additions, ())
+        self.assertEqual(empty.sch_b_dividend_additions, ())
+        self.assertEqual(empty.sch_d_short_term_additions, ())
+        self.assertEqual(empty.sch_d_long_term_additions, ())
+        self.assertEqual(empty.qbi_aggregate, 0.0)
+        self.assertEqual(empty.qualified_dividends_aggregate, 0.0)
+        self.assertEqual(empty.passive_activities, ())
+
+    def test_construct_with_activities(self) -> None:
+        from tenforty.models import (
+            EntityType, K1FanoutActivity, K1FanoutData, PayerAmount,
+        )
+        fanout = K1FanoutData(
+            sch_b_interest_additions=(PayerAmount(payer="X", amount=50.0),),
+            sch_b_dividend_additions=(),
+            sch_d_short_term_additions=(100.0,),
+            sch_d_long_term_additions=(),
+            qbi_aggregate=1000.0,
+            qualified_dividends_aggregate=0.0,
+            passive_activities=(
+                K1FanoutActivity(
+                    entity_name="A", entity_ein="00-0000000",
+                    entity_type=EntityType.PARTNERSHIP,
+                    income=0.0, loss=500.0, prior_carryforward=0.0,
+                ),
+            ),
+        )
+        self.assertEqual(len(fanout.passive_activities), 1)
+        self.assertEqual(fanout.sch_b_interest_additions[0].payer, "X")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -499,3 +499,40 @@ class TestVoluntaryContribution(unittest.TestCase):
         vc = VoluntaryContribution(fund_code="WLD", amount=10.0)
         with self.assertRaises(Exception):  # FrozenInstanceError
             vc.amount = 20.0  # type: ignore[misc]
+
+
+class TestTaxReturnConfigFullName(unittest.TestCase):
+    def _config(self, **kw) -> "TaxReturnConfig":
+        from tenforty.models import TaxReturnConfig
+        defaults = dict(
+            year=2025, filing_status="single", birthdate="1990-06-15", state="CA",
+            has_foreign_accounts=False, acknowledges_form_8949_unsupported=False,
+            acknowledges_sch_a_sales_tax_unsupported=False,
+            acknowledges_qbi_below_threshold=False,
+            acknowledges_unlimited_at_risk=False, basis_tracked_externally=False,
+            acknowledges_no_partnership_se_earnings=False,
+            acknowledges_no_section_1231_gain=False,
+            acknowledges_no_more_than_four_k1s=False,
+            acknowledges_no_k1_credits=False,
+            acknowledges_no_section_179=False,
+            acknowledges_no_estate_trust_k1=False,
+            prior_year_itemized=False,
+        )
+        defaults.update(kw)
+        return TaxReturnConfig(**defaults)
+
+    def test_concatenates_first_last(self) -> None:
+        cfg = self._config(first_name="Taxpayer", last_name="A")
+        self.assertEqual(cfg.full_name, "Taxpayer A")
+
+    def test_strips_whitespace(self) -> None:
+        cfg = self._config(first_name="  Taxpayer  ", last_name=" A ")
+        self.assertEqual(cfg.full_name, "Taxpayer A")
+
+    def test_both_empty_gives_empty_string(self) -> None:
+        cfg = self._config()
+        self.assertEqual(cfg.full_name, "")
+
+    def test_only_first(self) -> None:
+        cfg = self._config(first_name="Taxpayer")
+        self.assertEqual(cfg.full_name, "Taxpayer")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -536,3 +536,31 @@ class TestTaxReturnConfigFullName(unittest.TestCase):
     def test_only_first(self) -> None:
         cfg = self._config(first_name="Taxpayer")
         self.assertEqual(cfg.full_name, "Taxpayer")
+
+
+class TestScheduleK1EntityTypeEnum(unittest.TestCase):
+    def test_construct_with_enum_member(self) -> None:
+        from tenforty.models import EntityType, ScheduleK1
+        k1 = ScheduleK1(
+            entity_name="Fake S-Corp Inc", entity_ein="00-0000000",
+            entity_type=EntityType.S_CORP, material_participation=True,
+        )
+        self.assertIs(k1.entity_type, EntityType.S_CORP)
+
+    def test_construct_with_string_coerces_to_enum(self) -> None:
+        """YAML loader passes strings; dataclass coerces in __post_init__."""
+        from tenforty.models import EntityType, ScheduleK1
+        k1 = ScheduleK1(
+            entity_name="X", entity_ein="00-0000000",
+            entity_type="partnership", material_participation=False,
+        )
+        self.assertIs(k1.entity_type, EntityType.PARTNERSHIP)
+
+    def test_invalid_string_raises(self) -> None:
+        """Mis-routed entity_type fails at construction, not silently."""
+        from tenforty.models import ScheduleK1
+        with self.assertRaises(ValueError):
+            ScheduleK1(
+                entity_name="X", entity_ein="00-0000000",
+                entity_type="c_corp", material_participation=True,
+            )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -379,3 +379,30 @@ class ScenarioDepreciableAssetsTests(unittest.TestCase):
         self.assertEqual(a.description, "Rental building")
         self.assertEqual(a.basis, 250_000.0)
         self.assertEqual(a.recovery_class, "27.5-year")
+
+
+class TestEntityType(unittest.TestCase):
+    def test_values_match_plan_d_string_literal(self) -> None:
+        """The three entity types accepted by ScheduleK1 today."""
+        from tenforty.models import EntityType
+        self.assertEqual(EntityType.S_CORP.value, "s_corp")
+        self.assertEqual(EntityType.PARTNERSHIP.value, "partnership")
+        self.assertEqual(EntityType.ESTATE_TRUST.value, "estate_trust")
+
+    def test_is_str_subclass(self) -> None:
+        """str-Enum for YAML-loader friendliness (YAML yields strings)."""
+        from tenforty.models import EntityType
+        self.assertIsInstance(EntityType.S_CORP, str)
+        self.assertEqual(EntityType("s_corp"), EntityType.S_CORP)
+
+
+class TestAccountingMethod(unittest.TestCase):
+    def test_values(self) -> None:
+        from tenforty.models import AccountingMethod
+        self.assertEqual(AccountingMethod.CASH.value, "cash")
+        self.assertEqual(AccountingMethod.ACCRUAL.value, "accrual")
+        self.assertEqual(AccountingMethod.OTHER.value, "other")
+
+    def test_is_str_subclass(self) -> None:
+        from tenforty.models import AccountingMethod
+        self.assertIsInstance(AccountingMethod.CASH, str)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -99,3 +99,73 @@ class TestComputeOnceDiscipline(unittest.TestCase):
             f"sch_e_part_ii.compute was called {spy.call_count} times in "
             "one emit_pdfs; SP1-M1 requires at most once per compute stage.",
         )
+
+
+class TestShouldEmit8582ReadsFanout(unittest.TestCase):
+    """_should_emit_8582 must read K1FanoutData.passive_activities from
+    upstream, not re-loop scenario.schedule_k1s (SP1-M4)."""
+
+    def test_no_k1_no_rental_returns_false(self) -> None:
+        from tenforty.models import K1FanoutData
+        scenario = make_simple_scenario()
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=Path("spreadsheets"),
+            work_dir=Path("/tmp/tenforty-predicate"),
+        )
+        upstream = {"f1040": {}, "k1_fanout": K1FanoutData.empty()}
+        self.assertFalse(orchestrator._should_emit_8582(scenario, upstream))
+
+    def test_passive_activity_with_loss_returns_true(self) -> None:
+        from tenforty.models import (
+            EntityType, K1FanoutActivity, K1FanoutData,
+        )
+        scenario = make_simple_scenario()
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=Path("spreadsheets"),
+            work_dir=Path("/tmp/tenforty-predicate"),
+        )
+        fanout = K1FanoutData(
+            sch_b_interest_additions=(),
+            sch_b_dividend_additions=(),
+            sch_d_short_term_additions=(),
+            sch_d_long_term_additions=(),
+            qbi_aggregate=0.0,
+            qualified_dividends_aggregate=0.0,
+            passive_activities=(
+                K1FanoutActivity(
+                    entity_name="X", entity_ein="00-0000000",
+                    entity_type=EntityType.PARTNERSHIP,
+                    income=0.0, loss=500.0, prior_carryforward=0.0,
+                ),
+            ),
+        )
+        upstream = {"f1040": {}, "k1_fanout": fanout}
+        self.assertTrue(orchestrator._should_emit_8582(scenario, upstream))
+
+    def test_passive_activity_with_only_income_returns_false(self) -> None:
+        """No loss, no prior carryforward -> no 8582."""
+        from tenforty.models import (
+            EntityType, K1FanoutActivity, K1FanoutData,
+        )
+        scenario = make_simple_scenario()
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=Path("spreadsheets"),
+            work_dir=Path("/tmp/tenforty-predicate"),
+        )
+        fanout = K1FanoutData(
+            sch_b_interest_additions=(),
+            sch_b_dividend_additions=(),
+            sch_d_short_term_additions=(),
+            sch_d_long_term_additions=(),
+            qbi_aggregate=0.0,
+            qualified_dividends_aggregate=0.0,
+            passive_activities=(
+                K1FanoutActivity(
+                    entity_name="X", entity_ein="00-0000000",
+                    entity_type=EntityType.PARTNERSHIP,
+                    income=500.0, loss=0.0, prior_carryforward=0.0,
+                ),
+            ),
+        )
+        upstream = {"f1040": {}, "k1_fanout": fanout}
+        self.assertFalse(orchestrator._should_emit_8582(scenario, upstream))

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,10 +1,13 @@
+import inspect
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from tenforty.models import Scenario, TaxReturnConfig, W2
+from tenforty.forms import sch_e_part_ii as form_sch_e_part_ii
+from tenforty.models import EntityType, Scenario, ScheduleK1, TaxReturnConfig, W2
 from tenforty.orchestrator import ReturnOrchestrator
-from tests.helpers import SPREADSHEETS_DIR, needs_libreoffice
+from tests.helpers import SPREADSHEETS_DIR, make_simple_scenario, needs_libreoffice, needs_pdf
 
 
 @needs_libreoffice
@@ -42,3 +45,57 @@ class TestReturnOrchestrator(unittest.TestCase):
         # 80000 - 15750 = 64250
         self.assertEqual(results["taxable_income"], 64250)
         self.assertEqual(results["federal_withheld"], 12000)
+
+
+class TestShouldEmit8582AcceptsUpstream(unittest.TestCase):
+    """_should_emit_8582 gains an `upstream: UpstreamState` parameter in
+    Task 8 — signature-only, so its body is unchanged and still iterates
+    `scenario.schedule_k1s`. Task 9 rewrites the body to read upstream."""
+
+    def test_signature_accepts_upstream(self) -> None:
+        sig = inspect.signature(ReturnOrchestrator._should_emit_8582)
+        self.assertIn("upstream", sig.parameters)
+
+
+class TestComputeOnceDiscipline(unittest.TestCase):
+    """emit_pdfs must invoke form_sch_e_part_ii.compute at most once per call."""
+
+    @needs_libreoffice
+    @needs_pdf
+    def test_part_ii_called_at_most_once_across_emit_pdfs(self) -> None:
+        scenario = make_simple_scenario()
+        scenario.schedule_k1s = [
+            ScheduleK1(
+                entity_name="Fake S-Corp Inc", entity_ein="00-0000000",
+                entity_type=EntityType.S_CORP,
+                material_participation=True,
+                ordinary_business_income=50000.0, qbi_amount=50000.0,
+                interest_income=100.0,  # triggers Sch B
+                net_long_term_capital_gain=500.0,  # triggers Sch D
+            ),
+        ]
+        scenario.config.acknowledges_unlimited_at_risk = True
+        scenario.config.basis_tracked_externally = True
+        scenario.config.acknowledges_no_k1_credits = True
+
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=Path("spreadsheets"),
+            work_dir=Path("/tmp/tenforty-test-compute-once"),
+        )
+        results = orchestrator.compute_federal(scenario)
+
+        real_compute = form_sch_e_part_ii.compute
+        with patch(
+            "tenforty.orchestrator.form_sch_e_part_ii.compute",
+            side_effect=real_compute,
+        ) as spy:
+            orchestrator.emit_pdfs(
+                scenario, results,
+                output_dir=Path("/tmp/tenforty-test-compute-once-pdfs"),
+            )
+
+        self.assertLessEqual(
+            spy.call_count, 1,
+            f"sch_e_part_ii.compute was called {spy.call_count} times in "
+            "one emit_pdfs; SP1-M1 requires at most once per compute stage.",
+        )

--- a/tests/test_pdf_sch_e_mapping.py
+++ b/tests/test_pdf_sch_e_mapping.py
@@ -134,5 +134,42 @@ class PdfSchEPartIIStructureTests(unittest.TestCase):
         )
 
 
+class TestPdfSchERowsSnapshot(unittest.TestCase):
+    """Snapshot test for pdf_sch_e Part II row mapping (SP1-N9).
+
+    Ensures the loop-based row generator emits the exact same PDF field names
+    as the hand-written blocks so the refactor is bit-identical."""
+
+    def test_row_a_through_d_fields(self) -> None:
+        m = PdfSchE.get_mapping(2025)
+        scalars = m["scalars"]
+        expected = {
+            # Row A
+            "sch_e_part_ii_row_a_name":
+                "topmostSubform[0].Page2[0].Table_Line28a-f[0].RowA[0].f2_3[0]",
+            "sch_e_part_ii_row_a_ein":
+                "topmostSubform[0].Page2[0].Table_Line28a-f[0].RowA[0].f2_4[0]",
+            "sch_e_part_ii_row_a_entity_type_partnership":
+                "topmostSubform[0].Page2[0].Table_Line28a-f[0].RowA[0].c2_2[0]",
+            "sch_e_part_ii_row_a_entity_type_s_corp":
+                "topmostSubform[0].Page2[0].Table_Line28a-f[0].RowA[0].c2_3[0]",
+            "sch_e_part_ii_row_a_passive_loss":
+                "topmostSubform[0].Page2[0].Table_Line28g-k[0].RowA[0].f2_15[0]",
+            "sch_e_part_ii_row_a_passive_income":
+                "topmostSubform[0].Page2[0].Table_Line28g-k[0].RowA[0].f2_16[0]",
+            "sch_e_part_ii_row_a_nonpassive_loss":
+                "topmostSubform[0].Page2[0].Table_Line28g-k[0].RowA[0].f2_17[0]",
+            "sch_e_part_ii_row_a_nonpassive_income":
+                "topmostSubform[0].Page2[0].Table_Line28g-k[0].RowA[0].f2_19[0]",
+            # Row D (spot-check stride)
+            "sch_e_part_ii_row_d_name":
+                "topmostSubform[0].Page2[0].Table_Line28a-f[0].RowD[0].f2_12[0]",
+            "sch_e_part_ii_row_d_nonpassive_income":
+                "topmostSubform[0].Page2[0].Table_Line28g-k[0].RowD[0].f2_34[0]",
+        }
+        for k, expected_value in expected.items():
+            self.assertEqual(scalars.get(k), expected_value, f"field {k}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sch_e.py
+++ b/tests/test_sch_e.py
@@ -1,0 +1,37 @@
+"""Tests for forms.sch_e helpers."""
+
+import unittest
+
+from tenforty.forms import sch_e as form_sch_e
+from tenforty.models import RentalProperty
+from tests.helpers import make_simple_scenario
+
+
+class TestHasAnyNetLossUsesExpenseFields(unittest.TestCase):
+    def test_breakeven_is_not_a_loss(self) -> None:
+        scenario = make_simple_scenario()
+        scenario.rental_properties = [RentalProperty(
+            address="123 Example St",
+            property_type=1, fair_rental_days=365, personal_use_days=0,
+            rents_received=12000.0, mortgage_interest=6000.0, taxes=6000.0,
+        )]
+        self.assertFalse(form_sch_e.has_any_net_loss(scenario))
+
+    def test_net_loss_returns_true(self) -> None:
+        scenario = make_simple_scenario()
+        scenario.rental_properties = [RentalProperty(
+            address="123 Example St",
+            property_type=1, fair_rental_days=365, personal_use_days=0,
+            rents_received=6000.0, mortgage_interest=9000.0,
+        )]
+        self.assertTrue(form_sch_e.has_any_net_loss(scenario))
+
+    def test_body_does_not_hand_enumerate(self) -> None:
+        """The implementation must iterate _EXPENSE_FIELDS, not maintain a
+        parallel list of attribute names (SP1-M5)."""
+        import inspect
+        src = inspect.getsource(form_sch_e.has_any_net_loss)
+        self.assertNotIn("p.advertising", src)
+        self.assertNotIn("p.cleaning_and_maintenance", src)
+        self.assertNotIn("p.mortgage_interest", src)
+        self.assertIn("_EXPENSE_FIELDS", src)

--- a/tests/test_sch_e_part_ii.py
+++ b/tests/test_sch_e_part_ii.py
@@ -1,0 +1,77 @@
+"""Tests for sch_e_part_ii.compute's new tuple return."""
+
+import unittest
+
+from tenforty.forms import sch_e_part_ii as form_sch_e_part_ii
+from tenforty.models import (
+    EntityType, K1FanoutActivity, K1FanoutData, PayerAmount, ScheduleK1,
+)
+from tests.helpers import make_simple_scenario
+
+
+class TestComputeReturnShape(unittest.TestCase):
+    def test_compute_returns_tuple_of_dict_and_k1fanoutdata(self) -> None:
+        scenario = make_simple_scenario()
+        scenario.schedule_k1s = [
+            ScheduleK1(
+                entity_name="Fake S-Corp Inc", entity_ein="00-0000000",
+                entity_type=EntityType.S_CORP,
+                material_participation=True,
+                ordinary_business_income=50000.0, qbi_amount=50000.0,
+            ),
+        ]
+        scenario.config.acknowledges_unlimited_at_risk = True
+        scenario.config.basis_tracked_externally = True
+        scenario.config.acknowledges_no_k1_credits = True
+        result = form_sch_e_part_ii.compute(scenario, upstream={})
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        fields, fanout = result
+        self.assertIsInstance(fields, dict)
+        self.assertIsInstance(fanout, K1FanoutData)
+        self.assertEqual(fanout.qbi_aggregate, 50000.0)
+        self.assertNotIn("_k1_fanout", fields)
+
+    def test_passive_k1_produces_k1fanoutactivity(self) -> None:
+        scenario = make_simple_scenario()
+        scenario.schedule_k1s = [
+            ScheduleK1(
+                entity_name="Passive LP", entity_ein="00-0000000",
+                entity_type=EntityType.PARTNERSHIP,
+                material_participation=False,
+                ordinary_business_income=-2000.0,
+                prior_year_passive_loss_carryforward=500.0,
+            ),
+        ]
+        scenario.config.acknowledges_unlimited_at_risk = True
+        scenario.config.basis_tracked_externally = True
+        scenario.config.acknowledges_no_k1_credits = True
+        _, fanout = form_sch_e_part_ii.compute(scenario, upstream={})
+        self.assertEqual(len(fanout.passive_activities), 1)
+        a = fanout.passive_activities[0]
+        self.assertIsInstance(a, K1FanoutActivity)
+        self.assertEqual(a.entity_name, "Passive LP")
+        self.assertEqual(a.entity_type, EntityType.PARTNERSHIP)
+        self.assertEqual(a.income, 0)
+        self.assertEqual(a.loss, 2000)
+        self.assertEqual(a.prior_carryforward, 500)
+
+    def test_payer_amount_for_k1_interest(self) -> None:
+        scenario = make_simple_scenario()
+        scenario.schedule_k1s = [
+            ScheduleK1(
+                entity_name="Int Source LP", entity_ein="00-0000000",
+                entity_type=EntityType.PARTNERSHIP,
+                material_participation=True,
+                interest_income=250.0,
+            ),
+        ]
+        scenario.config.acknowledges_unlimited_at_risk = True
+        scenario.config.basis_tracked_externally = True
+        scenario.config.acknowledges_no_k1_credits = True
+        _, fanout = form_sch_e_part_ii.compute(scenario, upstream={})
+        self.assertEqual(len(fanout.sch_b_interest_additions), 1)
+        pa = fanout.sch_b_interest_additions[0]
+        self.assertIsInstance(pa, PayerAmount)
+        self.assertEqual(pa.payer, "Int Source LP")
+        self.assertEqual(pa.amount, 250.0)

--- a/tests/test_sch_e_part_ii.py
+++ b/tests/test_sch_e_part_ii.py
@@ -75,3 +75,37 @@ class TestComputeReturnShape(unittest.TestCase):
         self.assertIsInstance(pa, PayerAmount)
         self.assertEqual(pa.payer, "Int Source LP")
         self.assertEqual(pa.amount, 250.0)
+
+
+class TestK1RowTotalHelper(unittest.TestCase):
+    """`_k1_row_total` aggregates the Sch E Part II row-total components
+    (ordinary business income + net rental + royalties + other income) after
+    IRS rounding per component. Extraction target of SP1-N7."""
+
+    def test_helper_matches_inline_expression(self) -> None:
+        from tenforty.forms.sch_e_part_ii import _k1_row_total
+        from tenforty.models import EntityType, ScheduleK1
+        from tenforty.rounding import irs_round
+        k1 = ScheduleK1(
+            entity_name="X", entity_ein="00-0000000",
+            entity_type=EntityType.S_CORP, material_participation=True,
+            ordinary_business_income=1234.56,
+            net_rental_real_estate=100.40, other_net_rental=50.10,
+            royalties=200.49, other_income=10.01,
+        )
+        expected = (
+            irs_round(1234.56)
+            + irs_round(100.40 + 50.10)
+            + irs_round(200.49)
+            + irs_round(10.01)
+        )
+        self.assertEqual(expected, _k1_row_total(k1))
+
+    def test_helper_zero_on_empty_k1(self) -> None:
+        from tenforty.forms.sch_e_part_ii import _k1_row_total
+        from tenforty.models import EntityType, ScheduleK1
+        k1 = ScheduleK1(
+            entity_name="X", entity_ein="00-0000000",
+            entity_type=EntityType.S_CORP, material_participation=True,
+        )
+        self.assertEqual(0.0, _k1_row_total(k1))

--- a/tests/test_sch_e_part_ii_compute.py
+++ b/tests/test_sch_e_part_ii_compute.py
@@ -85,7 +85,7 @@ class RowLayoutTests(unittest.TestCase):
     def test_one_scorp_active_row_a_nonpassive(self):
         s = make_k1_scenario()
         s.schedule_k1s = [_scorp_k1(ordinary_business_income=50_000.0)]
-        out = sch_e_part_ii.compute(s, upstream={})
+        out, _ = sch_e_part_ii.compute(s, upstream={})
         self.assertEqual(out["sch_e_part_ii_row_a_name"], "Fake S-Corp Inc")
         self.assertEqual(out["sch_e_part_ii_row_a_ein"], "00-0000000")
         self.assertEqual(out["sch_e_part_ii_row_a_entity_type_s_corp"], "X")
@@ -100,7 +100,7 @@ class RowLayoutTests(unittest.TestCase):
             material_participation=False,
             ordinary_business_income=10_000.0,
         )]
-        out = sch_e_part_ii.compute(s, upstream={})
+        out, _ = sch_e_part_ii.compute(s, upstream={})
         self.assertEqual(out["sch_e_part_ii_row_a_passive_income"], 10_000)
         self.assertEqual(out["sch_e_part_ii_row_a_nonpassive_income"], 0)
 
@@ -114,14 +114,15 @@ class FanoutTests(unittest.TestCase):
             qualified_dividends=200.0,
             qbi_amount=50_000.0,
         )]
-        out = sch_e_part_ii.compute(s, upstream={})
-        fan = out["_k1_fanout"]
-        self.assertEqual(fan["interest_from_k1s"],
-                         [{"payer": "Fake S-Corp Inc", "amount": 500.0}])
-        self.assertEqual(fan["ordinary_dividends_from_k1s"],
-                         [{"payer": "Fake S-Corp Inc", "amount": 250.0}])
-        self.assertEqual(fan["qualified_dividends_total"], 200.0)
-        self.assertEqual(fan["qbi_total"], 50_000.0)
+        _, fan = sch_e_part_ii.compute(s, upstream={})
+        self.assertEqual(len(fan.sch_b_interest_additions), 1)
+        self.assertEqual(fan.sch_b_interest_additions[0].payer, "Fake S-Corp Inc")
+        self.assertEqual(fan.sch_b_interest_additions[0].amount, 500.0)
+        self.assertEqual(len(fan.sch_b_dividend_additions), 1)
+        self.assertEqual(fan.sch_b_dividend_additions[0].payer, "Fake S-Corp Inc")
+        self.assertEqual(fan.sch_b_dividend_additions[0].amount, 250.0)
+        self.assertEqual(fan.qualified_dividends_aggregate, 200.0)
+        self.assertEqual(fan.qbi_aggregate, 50_000.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_sch_e_part_ii_oracle.py
+++ b/tests/test_sch_e_part_ii_oracle.py
@@ -48,7 +48,7 @@ class SchEPartIIOracleTests(unittest.TestCase):
         )
         s = make_k1_scenario()
         s.schedule_k1s = [k1]
-        got = sch_e_part_ii.compute(s, upstream={})
+        got, _ = sch_e_part_ii.compute(s, upstream={})
         self._assert_row_matches("a", k1, got)
 
     def test_partnership_passive_matches_oracle(self):
@@ -62,5 +62,5 @@ class SchEPartIIOracleTests(unittest.TestCase):
         )
         s = make_k1_scenario()
         s.schedule_k1s = [k1]
-        got = sch_e_part_ii.compute(s, upstream={})
+        got, _ = sch_e_part_ii.compute(s, upstream={})
         self._assert_row_matches("a", k1, got)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,33 @@
+"""Structural tests for tenforty.types."""
+
+import unittest
+from typing import get_type_hints
+
+from tenforty.types import UpstreamState
+
+
+class TestUpstreamState(unittest.TestCase):
+    def test_is_total_false(self) -> None:
+        """UpstreamState keys must be optional so unset keys are a KeyError,
+        not a silent None. total=False is the contract enforced by spec §M1."""
+        self.assertFalse(getattr(UpstreamState, "__total__", True))
+
+    def test_has_exact_pass_1_keys(self) -> None:
+        """Pass 1 keys: the forms that exist today plus the typed k1_fanout sidecar.
+
+        Uses set equality (not issubset) so that a typo adding or removing
+        a key surfaces as a test failure. Sub-plans 1–4 will extend this
+        list in lockstep with test expectations."""
+        hints = get_type_hints(UpstreamState)
+        expected = {
+            "f1040", "sch_1", "sch_a", "sch_b", "sch_d", "sch_e",
+            "sch_e_part_ii", "f4562", "f8582", "f8959", "f8995",
+            "k1_fanout",
+        }
+        self.assertEqual(expected, set(hints))
+
+    def test_k1_fanout_is_k1fanoutdata(self) -> None:
+        """The k1_fanout value is the typed sidecar, not a dict."""
+        from tenforty.models import K1FanoutData
+        hints = get_type_hints(UpstreamState)
+        self.assertIs(hints["k1_fanout"], K1FanoutData)


### PR DESCRIPTION
Closes #21. Parent: #20.

## Summary

19 commits on `pass-1-cleanup`, one commit per plan task (plan #21), closing 12 `/simplify` findings on the Plan D diff (6 material SP1-M*, 6 nit SP1-N*) plus 2 forward-compatibility additions (`UpstreamState`, `VoluntaryContribution`) the sub-plans 1–4 architecture expects.

No new feature work. No behavior-affecting changes to computed forms beyond what the plan's TDD tests cover.

## SP1 items landed

- **SP1-M1** — `sch_e_part_ii.compute` hoisted to run at most once per `emit_pdfs` (orchestrator compute-once discipline)
- **SP1-M2** — `_ATTESTATIONS` table drives load + compute gates (attestation table + `make_simple_scenario` posture migration, split across two commits per spec review)
- **SP1-M3** — `ScheduleK1.entity_type` promoted from `Literal` to `EntityType` enum
- **SP1-M4** — `_should_emit_8582` reads `upstream["k1_fanout"]` (no re-classification)
- **SP1-M5** — `has_any_net_loss` iterates shared `_EXPENSE_FIELDS` constant
- **SP1-M6** — `sch_e_part_ii.compute` returns typed `K1FanoutData` sidecar (replaces dict-of-lists-of-dicts)
- **SP1-N7** — `_k1_row_total` helper extracted (deduplicates two call sites)
- **SP1-N8** — 11 inline `first_name / last_name` sites collapsed to `config.full_name`; `TaxReturnConfig.full_name` property added
- **SP1-N9** — `pdf_sch_e` rows A–D emitted via generator (replaces 4 hand-enumerated blocks)
- **SP1-N10** — redundant `FilingStatus(scenario.config.filing_status)` cast dropped
- **SP1-N11** — stale Plan-D / Task-N narration stripped across 11 files (iron law 10, WHY-not-WHAT)
- **SP1-N12** — duplicated rationale in `f8995` / `f8582` consolidated

## Forward-compat additions

- `UpstreamState` TypedDict — typed state threaded through compute stages
- `VoluntaryContribution` dataclass — CA540 forward-compat slot

## Acceptance

- Full suite (serial, `-p no:xdist`): `497 passed, 8 failed, 21 skipped`. The 8 pre-existing failures are `TestE2ECapitalGains` / `TestE2EComprehensive` cases blocked on 1099-B / K-1 work — tracked outside this plan.
- 12 SP1 grep checks clean.
- Iron Law 3 grep clean (no module-level `def test_` — every test lives in a `TestCase` subclass).
- `scripts/verify_no_personal_data.py` — exit 0.
- No squash, no amend, no "wip" commits. Every commit is conventional-prefix + SP1 tag where applicable.

## Known noise

pytest-xdist produces 11–17 spurious failures under parallel workers; serial runs are stable. Filed separately as #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)