### PR TITLE
Wire Sch 1 per-line breakdowns through compute_federal

### DIFF
--- a/tenforty/forms/f1040.py
+++ b/tenforty/forms/f1040.py
@@ -31,6 +31,34 @@ assert not (set(_RENAMES) & set(_ALIASES)), (
 )
 
 
+# Numeric Sch 1 line keys whose underlying XLS cells may resolve to
+# Python None (raw input cells, blank when no input given). Downstream
+# consumers (Sch CA kernel auto-derive) do arithmetic on these values;
+# None would TypeError. The rekey shim canonicalizes None -> 0 here so
+# every consumer can rely on a numeric type.
+_NUMERIC_SCH_1_KEYS: frozenset[str] = frozenset({
+    "sch_1_line_1_taxable_refunds",
+    "sch_1_line_3_business_income",
+    "sch_1_line_4_other_gains",
+    "sch_1_line_5_rental_re_royalty",
+    "sch_1_line_6_farm_income",
+    "sch_1_line_7_unemployment",
+    # Both forms of line 10 and line 26 are aliased; coerce both so the
+    # mirror invariant (short == long) holds even when the underlying
+    # workbook cell returns None.
+    "sch_1_line_10",
+    "sch_1_line_10_total_additional_income",
+    "sch_1_line_11_educator",
+    "sch_1_line_13_hsa",
+    "sch_1_line_15_se_tax",
+    "sch_1_line_17_se_health",
+    "sch_1_line_20_ira",
+    "sch_1_line_21_student_loan_interest",
+    "sch_1_line_26",
+    "sch_1_line_26_total_adjustments",
+})
+
+
 def compute(raw_1040: dict, upstream: dict[str, dict]) -> dict:
     """Translate raw engine output into a PDF-ready 1040 result dict."""
     translated: dict = dict(raw_1040)
@@ -42,6 +70,10 @@ def compute(raw_1040: dict, upstream: dict[str, dict]) -> dict:
     for old, new in _ALIASES.items():
         if old in translated:
             translated[new] = translated[old]
+
+    for key in _NUMERIC_SCH_1_KEYS:
+        if translated.get(key) is None:
+            translated[key] = 0
 
     if "agi" in translated:
         translated["agi_page2"] = translated["agi"]

--- a/tenforty/forms/f1040.py
+++ b/tenforty/forms/f1040.py
@@ -21,6 +21,8 @@ _RENAMES: dict[str, str] = {
 # native math) to read either name without a second lookup.
 _ALIASES: dict[str, str] = {
     "schd_line16": "capital_gain_loss",
+    "sch_1_line_10": "sch_1_line_10_total_additional_income",
+    "sch_1_line_26": "sch_1_line_26_total_adjustments",
 }
 
 assert not (set(_RENAMES) & set(_ALIASES)), (

--- a/tenforty/mappings/f1040.py
+++ b/tenforty/mappings/f1040.py
@@ -436,6 +436,14 @@ class F1040(FormMapping):
             "sch_1_line_5_rental_re_royalty": "SchE_IncomeLoss",
             "sch_1_line_6_farm_income": "FarmIncomeLoss",
             "sch_1_line_7_unemployment": "UnEmploymentComp",
+            # Schedule 1 Part II per-line breakdowns (XLS-sourced;
+            # named ranges in the Sch. 1 sheet).
+            "sch_1_line_11_educator": "EducatorExpenses",
+            "sch_1_line_13_hsa": "HSA_Deduct",
+            "sch_1_line_15_se_tax": "SE_Deduct",
+            "sch_1_line_17_se_health": "SEHealthInsDeduct",
+            "sch_1_line_20_ira": "IRADeduct",
+            "sch_1_line_21_student_loan_interest": "StudentLoanIntDeduct",
             "sche_line41": "SchE1_Line41",
             "schd_line16": "SchDLine16",
             "interest_income": "Interest_Inc",

--- a/tenforty/mappings/f1040.py
+++ b/tenforty/mappings/f1040.py
@@ -419,6 +419,15 @@ class F1040(FormMapping):
             # Schedule 1 line 26 (Total Adjustments to Income). Oracle
             # cross-check target for forms.sch_1.compute's native math.
             "sch_1_line_26": "Sch1A_Deductions",
+            # Schedule 1 Part I per-line breakdowns (XLS-sourced; named
+            # ranges in the Sch. 1 sheet). These keys feed downstream
+            # Sch CA kernel auto-derive and other state-return
+            # consumers that need per-line granularity.
+            "sch_1_line_1_taxable_refunds": "Sch1_Line1",
+            "sch_1_line_3_business_income": "BusinessIncomeLoss",
+            "sch_1_line_5_rental_re_royalty": "SchE_IncomeLoss",
+            "sch_1_line_6_farm_income": "FarmIncomeLoss",
+            "sch_1_line_7_unemployment": "UnEmploymentComp",
             "sche_line41": "SchE1_Line41",
             "schd_line16": "SchDLine16",
             "interest_income": "Interest_Inc",

--- a/tenforty/mappings/f1040.py
+++ b/tenforty/mappings/f1040.py
@@ -220,6 +220,11 @@ class F1040(FormMapping):
             "g_taxable_grants_6": "1099-G",
             "g_ag_6": "1099-G",
             "g_market_gain_6": "1099-G",
+            # Schedule 1 line 4 (other gains/losses): direct cell ref
+            # because the value isn't named in the workbook. Cell AJ19
+            # holds ROUND(AC19,0); line 10's SUM references the same
+            # rounded expression inline.
+            "sch_1_line_4_other_gains": "Sch. 1",
             **_f8949_all_sheet_map(),
         },
     }
@@ -425,6 +430,9 @@ class F1040(FormMapping):
             # consumers that need per-line granularity.
             "sch_1_line_1_taxable_refunds": "Sch1_Line1",
             "sch_1_line_3_business_income": "BusinessIncomeLoss",
+            # Line 4 has no named range; direct cell ref to AJ19
+            # (rounded display of AC19). SHEET_MAP routes to "Sch. 1".
+            "sch_1_line_4_other_gains": "AJ19",
             "sch_1_line_5_rental_re_royalty": "SchE_IncomeLoss",
             "sch_1_line_6_farm_income": "FarmIncomeLoss",
             "sch_1_line_7_unemployment": "UnEmploymentComp",

--- a/tenforty/oracle/engine.py
+++ b/tenforty/oracle/engine.py
@@ -46,7 +46,7 @@ class SpreadsheetEngine:
 
         self._write_inputs(working_copy, input_map, sheet_map, inputs)
         recalculated = self._recalculate(working_copy, work_dir)
-        return self._read_outputs(recalculated, output_map)
+        return self._read_outputs(recalculated, output_map, sheet_map)
 
     def _write_inputs(
         self,
@@ -140,18 +140,21 @@ class SpreadsheetEngine:
         self,
         workbook_path: Path,
         output_map: dict[str, str],
+        sheet_map: dict[str, str],
     ) -> dict[str, object]:
         wb = openpyxl.load_workbook(workbook_path, data_only=True)
         named_ranges = {n.name: n for n in wb.defined_names.values()}
         results: dict[str, object] = {}
 
-        for output_key, named_range in output_map.items():
-            if named_range not in named_ranges:
+        for output_key, cell_ref in output_map.items():
+            if cell_ref in named_ranges:
+                defn = named_ranges[cell_ref]
+                sheet_name, cell_addr = _resolve_named_range(defn)
+                results[output_key] = wb[sheet_name][cell_addr].value
+            elif output_key in sheet_map:
+                sheet_name = sheet_map[output_key]
+                results[output_key] = wb[sheet_name][cell_ref].value
+            else:
                 results[output_key] = None
-                continue
-
-            defn = named_ranges[named_range]
-            sheet_name, cell_addr = _resolve_named_range(defn)
-            results[output_key] = wb[sheet_name][cell_addr].value
 
         return results

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -48,3 +48,50 @@ class TestSpreadsheetEngine(unittest.TestCase):
         self.assertGreater(results["total_tax"], 13000)
         self.assertLess(results["total_tax"], 14000)
         self.assertGreater(results["overpaid"], 0)
+
+
+@needs_libreoffice
+class SheetMapFallbackForOutputs(unittest.TestCase):
+    """OUTPUTS entries that aren't named ranges should fall back to
+    SHEET_MAP routing, mirroring the INPUTS-side behavior in
+    _write_inputs. Without the fallback, direct cell-ref OUTPUTS
+    silently resolve to None.
+    """
+
+    def test_cell_ref_output_resolves_via_sheet_map(self):
+        federal_1040_path = SPREADSHEETS_DIR / "federal" / "2025" / "1040.xlsx"
+        if not federal_1040_path.exists():
+            self.skipTest(f"Federal 1040 spreadsheet not found at {federal_1040_path}")
+
+        class _TestMapping:
+            INPUTS = {2025: {"w2_wages_1": "C3"}}
+            OUTPUTS = {2025: {
+                # Named range — control: must continue to work.
+                "wages_named": "Wages",
+                # Cell ref — exercises the new SHEET_MAP fallback path.
+                "wages_cell_ref": "C3",
+            }}
+            SHEET_MAP = {2025: {
+                "w2_wages_1": "W-2s",
+                "wages_cell_ref": "W-2s",
+            }}
+
+            @classmethod
+            def get_inputs(cls, year):
+                return cls.INPUTS[year]
+
+            @classmethod
+            def get_outputs(cls, year):
+                return cls.OUTPUTS[year]
+
+        tmp_path = Path(tempfile.mkdtemp())
+        engine = SpreadsheetEngine()
+        results = engine.compute(
+            spreadsheet_path=federal_1040_path,
+            mapping=_TestMapping,
+            year=2025,
+            inputs={"w2_wages_1": 100000},
+            work_dir=tmp_path,
+        )
+        self.assertEqual(results["wages_named"], 100000)
+        self.assertEqual(results["wages_cell_ref"], 100000)

--- a/tests/test_f1040_mapping.py
+++ b/tests/test_f1040_mapping.py
@@ -105,7 +105,18 @@ class TestF1040MappingValidity(unittest.TestCase):
                 continue
             wb = openpyxl.load_workbook(workbook_path, read_only=False)
             inputs = F1040.get_inputs(year)
+            outputs = F1040.get_outputs(year)
             for key, sheet_name in sheet_map.items():
+                # SHEET_MAP serves both input writes and output reads (the
+                # engine falls back to SHEET_MAP in _write_inputs and
+                # _read_outputs alike). Merged-cell concern only applies
+                # to writes — reading a merged cell is safe.
+                if key not in inputs:
+                    self.assertIn(
+                        key, outputs,
+                        f"{year} SHEET_MAP key '{key}' is in neither INPUTS nor OUTPUTS",
+                    )
+                    continue
                 cell_ref = inputs[key]
                 cell = wb[sheet_name][cell_ref]
                 self.assertNotIsInstance(

--- a/tests/test_orchestrator_compute_federal_keys.py
+++ b/tests/test_orchestrator_compute_federal_keys.py
@@ -90,3 +90,20 @@ class ComputeFederalExposesSch1PartIPerLine(unittest.TestCase):
                 results[key], 0,
                 f"expected zero for {key} in simple W-2-only scenario",
             )
+
+
+@needs_libreoffice
+class ComputeFederalExposesSch1Line4(unittest.TestCase):
+    """Line 4 (other gains) has no named range — direct cell ref via
+    SHEET_MAP. The simple-scenario value is zero, but the key must be
+    present so kernel auto-derive can read it."""
+
+    def test_line_4_present_in_results(self):
+        scenario = make_simple_scenario()
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=SPREADSHEETS_DIR,
+            work_dir=Path(tempfile.mkdtemp()),
+        )
+        results = orchestrator.compute_federal(scenario)
+        self.assertIn("sch_1_line_4_other_gains", results)
+        self.assertEqual(results["sch_1_line_4_other_gains"], 0)

--- a/tests/test_orchestrator_compute_federal_keys.py
+++ b/tests/test_orchestrator_compute_federal_keys.py
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tenforty.forms.sch_1 import compute as sch_1_compute
 from tenforty.models import Form1099G
 from tenforty.orchestrator import ReturnOrchestrator
 from tests.helpers import (
@@ -153,3 +154,63 @@ class ComputeFederalExposesSch1PartIIPerLine(unittest.TestCase):
         results = orchestrator.compute_federal(scenario)
         self.assertEqual(results["sch_1_line_21_student_loan_interest"], 0)
         self.assertIsNotNone(results["sch_1_line_21_student_loan_interest"])
+
+
+@needs_libreoffice
+class XlsAgreesWithNativeSch1ForNonK1Scenario(unittest.TestCase):
+    """Sanity: for a non-K-1 scenario, the XLS-sourced per-line keys in
+    compute_federal results agree with what forms/sch_1.compute would
+    produce reading the same merged result dict as upstream. This
+    pins path (a) and the native compute as consistent for scenarios
+    that don't trip the Sch E Part II blind spot.
+    """
+
+    def test_unemployment_scenario_xls_matches_native(self):
+        scenario = make_simple_scenario()
+        scenario.form1099_g = [
+            Form1099G(payer="State", unemployment_compensation=4_200.0),
+        ]
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=SPREADSHEETS_DIR,
+            work_dir=Path(tempfile.mkdtemp()),
+        )
+        results = orchestrator.compute_federal(scenario)
+
+        # The native compute reads `sch_e_line_26_total` from upstream
+        # to drive line 5; results carries `sche_line26` (oracle key)
+        # but not the renamed sch_e_line_26_total. Build an upstream
+        # snapshot mirroring what the orchestrator's _compute_1040_pipeline
+        # would synthesize.
+        upstream = {
+            "f1040": results,
+            "sch_e": {
+                "sch_e_line_26_total": results.get("sche_line26", 0),
+            },
+        }
+        native = sch_1_compute(scenario, upstream)
+
+        # Path-(a) XLS values must agree with native compute on every
+        # per-line key the native module computes. Line 4 (other gains)
+        # is intentionally excluded — native sch_1.compute hard-zeros it,
+        # so any oracle non-zero would flag a divergence we don't yet
+        # have native coverage for.
+        for key in [
+            "sch_1_line_1_taxable_refunds",
+            "sch_1_line_3_business_income",
+            "sch_1_line_5_rental_re_royalty",
+            "sch_1_line_6_farm_income",
+            "sch_1_line_7_unemployment",
+            "sch_1_line_11_educator",
+            "sch_1_line_13_hsa",
+            "sch_1_line_15_se_tax",
+            "sch_1_line_17_se_health",
+            "sch_1_line_20_ira",
+            "sch_1_line_21_student_loan_interest",
+            "sch_1_line_10_total_additional_income",
+            "sch_1_line_26_total_adjustments",
+        ]:
+            self.assertEqual(
+                results[key],
+                native[key],
+                f"path-(a)/native disagreement on {key}",
+            )

--- a/tests/test_orchestrator_compute_federal_keys.py
+++ b/tests/test_orchestrator_compute_federal_keys.py
@@ -45,3 +45,48 @@ class ComputeFederalExposesSch1LongFormTotals(unittest.TestCase):
             results["sch_1_line_26_total_adjustments"],
             results["sch_1_line_26"],
         )
+
+
+@needs_libreoffice
+class ComputeFederalExposesSch1PartIPerLine(unittest.TestCase):
+    """Part I per-line breakdown keys (lines 1, 3, 5, 6, 7).
+
+    Line 4 (other gains) is covered separately in
+    ComputeFederalExposesSch1Line4 because it lacks a named range and
+    requires a SHEET_MAP entry rather than a named-range OUTPUTS entry.
+    """
+
+    def test_unemployment_appears_as_sch_1_line_7(self):
+        scenario = make_simple_scenario()
+        scenario.form1099_g = [
+            Form1099G(payer="State", unemployment_compensation=5000.0),
+        ]
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=SPREADSHEETS_DIR,
+            work_dir=Path(tempfile.mkdtemp()),
+        )
+        results = orchestrator.compute_federal(scenario)
+        self.assertEqual(results["sch_1_line_7_unemployment"], 5000)
+
+    def test_part_i_lines_present_for_simple_scenario(self):
+        """Even a no-Sch-1-income scenario should expose all Part I keys
+        as zero — kernel auto-derive needs the keys to exist before it
+        can read them."""
+        scenario = make_simple_scenario()
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=SPREADSHEETS_DIR,
+            work_dir=Path(tempfile.mkdtemp()),
+        )
+        results = orchestrator.compute_federal(scenario)
+        for key in [
+            "sch_1_line_1_taxable_refunds",
+            "sch_1_line_3_business_income",
+            "sch_1_line_5_rental_re_royalty",
+            "sch_1_line_6_farm_income",
+            "sch_1_line_7_unemployment",
+        ]:
+            self.assertIn(key, results, f"missing Part I key: {key}")
+            self.assertEqual(
+                results[key], 0,
+                f"expected zero for {key} in simple W-2-only scenario",
+            )

--- a/tests/test_orchestrator_compute_federal_keys.py
+++ b/tests/test_orchestrator_compute_federal_keys.py
@@ -179,8 +179,9 @@ class XlsAgreesWithNativeSch1ForNonK1Scenario(unittest.TestCase):
         # The native compute reads `sch_e_line_26_total` from upstream
         # to drive line 5; results carries `sche_line26` (oracle key)
         # but not the renamed sch_e_line_26_total. Build an upstream
-        # snapshot mirroring what the orchestrator's _compute_1040_pipeline
-        # would synthesize.
+        # snapshot mirroring what the orchestrator's _emit_pdfs_internal
+        # synthesizes when it calls sch_1.compute (see orchestrator.py
+        # ~line 413: `upstream={**upstream, "sch_e": sch_e_values}`).
         upstream = {
             "f1040": results,
             "sch_e": {

--- a/tests/test_orchestrator_compute_federal_keys.py
+++ b/tests/test_orchestrator_compute_federal_keys.py
@@ -107,3 +107,49 @@ class ComputeFederalExposesSch1Line4(unittest.TestCase):
         results = orchestrator.compute_federal(scenario)
         self.assertIn("sch_1_line_4_other_gains", results)
         self.assertEqual(results["sch_1_line_4_other_gains"], 0)
+
+
+@needs_libreoffice
+class ComputeFederalExposesSch1PartIIPerLine(unittest.TestCase):
+    """Part II per-line breakdown keys (lines 11, 13, 15, 17, 20, 21).
+
+    A simple W-2 scenario doesn't drive any of these; we just assert
+    the keys exist and are zero so kernel auto-derive can read them
+    without KeyError guards.
+    """
+
+    def test_part_ii_lines_present_for_simple_scenario(self):
+        scenario = make_simple_scenario()
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=SPREADSHEETS_DIR,
+            work_dir=Path(tempfile.mkdtemp()),
+        )
+        results = orchestrator.compute_federal(scenario)
+        for key in [
+            "sch_1_line_11_educator",
+            "sch_1_line_13_hsa",
+            "sch_1_line_15_se_tax",
+            "sch_1_line_17_se_health",
+            "sch_1_line_20_ira",
+            "sch_1_line_21_student_loan_interest",
+        ]:
+            self.assertIn(key, results, f"missing Part II key: {key}")
+            self.assertEqual(
+                results[key], 0,
+                f"expected zero for {key} in simple W-2-only scenario",
+            )
+
+    def test_student_loan_interest_coerced_from_none_to_zero(self):
+        """Line 21's named range points at a raw input cell that
+        resolves to None (not 0) for an empty scenario. The rekey
+        shim's _NUMERIC_SCH_1_KEYS coercion canonicalizes that to
+        a numeric 0 so downstream kernel arithmetic doesn't TypeError.
+        """
+        scenario = make_simple_scenario()
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=SPREADSHEETS_DIR,
+            work_dir=Path(tempfile.mkdtemp()),
+        )
+        results = orchestrator.compute_federal(scenario)
+        self.assertEqual(results["sch_1_line_21_student_loan_interest"], 0)
+        self.assertIsNotNone(results["sch_1_line_21_student_loan_interest"])

--- a/tests/test_orchestrator_compute_federal_keys.py
+++ b/tests/test_orchestrator_compute_federal_keys.py
@@ -1,0 +1,47 @@
+"""Regression coverage: compute_federal exposes Schedule 1 per-line keys.
+
+These keys are consumed downstream by the Sch CA kernel auto-derive
+(sub-plan 3) so that California adjustments fire on the same line
+breakdowns the IRS Sch 1 PDF carries. The values come from the XLS
+oracle via the f1040 rekey shim; this test pins the contract that
+those keys are present in the merged compute_federal result dict.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tenforty.models import Form1099G
+from tenforty.orchestrator import ReturnOrchestrator
+from tests.helpers import (
+    SPREADSHEETS_DIR,
+    make_simple_scenario,
+    needs_libreoffice,
+)
+
+
+@needs_libreoffice
+class ComputeFederalExposesSch1LongFormTotals(unittest.TestCase):
+    """Long-form aliases for the existing line 10 / line 26 totals."""
+
+    def test_long_form_line_10_and_line_26_totals_appear(self):
+        scenario = make_simple_scenario()
+        scenario.form1099_g = [
+            Form1099G(payer="State", unemployment_compensation=5000.0),
+        ]
+        orchestrator = ReturnOrchestrator(
+            spreadsheets_dir=SPREADSHEETS_DIR,
+            work_dir=Path(tempfile.mkdtemp()),
+        )
+        results = orchestrator.compute_federal(scenario)
+        self.assertIn("sch_1_line_10_total_additional_income", results)
+        self.assertIn("sch_1_line_26_total_adjustments", results)
+        # The long-form values mirror the short-form aliases.
+        self.assertEqual(
+            results["sch_1_line_10_total_additional_income"],
+            results["sch_1_line_10"],
+        )
+        self.assertEqual(
+            results["sch_1_line_26_total_adjustments"],
+            results["sch_1_line_26"],
+        )

--- a/tests/test_orchestrator_compute_federal_keys.py
+++ b/tests/test_orchestrator_compute_federal_keys.py
@@ -161,8 +161,8 @@ class XlsAgreesWithNativeSch1ForNonK1Scenario(unittest.TestCase):
     """Sanity: for a non-K-1 scenario, the XLS-sourced per-line keys in
     compute_federal results agree with what forms/sch_1.compute would
     produce reading the same merged result dict as upstream. This
-    pins path (a) and the native compute as consistent for scenarios
-    that don't trip the Sch E Part II blind spot.
+    pins the XLS oracle path and the native compute as consistent for
+    scenarios that don't trip the Sch E Part II blind spot.
     """
 
     def test_unemployment_scenario_xls_matches_native(self):
@@ -190,7 +190,7 @@ class XlsAgreesWithNativeSch1ForNonK1Scenario(unittest.TestCase):
         }
         native = sch_1_compute(scenario, upstream)
 
-        # Path-(a) XLS values must agree with native compute on every
+        # XLS-oracle values must agree with native compute on every
         # per-line key the native module computes. Line 4 (other gains)
         # is intentionally excluded — native sch_1.compute hard-zeros it,
         # so any oracle non-zero would flag a divergence we don't yet
@@ -213,5 +213,5 @@ class XlsAgreesWithNativeSch1ForNonK1Scenario(unittest.TestCase):
             self.assertEqual(
                 results[key],
                 native[key],
-                f"path-(a)/native disagreement on {key}",
+                f"XLS-oracle/native disagreement on {key}",
             )


### PR DESCRIPTION
## Summary

Wires Schedule 1 per-line breakdowns (Part I lines 1, 3, 4, 5, 6, 7 + Part II lines 11, 13, 15, 17, 20, 21) plus long-form aliases for the existing line 10 and line 26 totals through `ReturnOrchestrator.compute_federal()` results, sourced from the XLS oracle via the `tenforty.forms.f1040` rekey shim. Twelve named-range OUTPUTS entries land in `tenforty.mappings.f1040.F1040`; line 4 (no named range) uses a direct cell ref to `Sch. 1!AJ19`, which prompted a small extension to `tenforty.oracle.engine._read_outputs` to mirror the SHEET_MAP fallback already present in `_write_inputs`.

The shim now coerces None→0 for an explicit `_NUMERIC_SCH_1_KEYS` allowlist so empty raw-input cells (notably line 21's `StudentLoanIntDeduct`) don't TypeError at downstream consumers. The mirror invariant `sch_1_line_10 == sch_1_line_10_total_additional_income` (and same for line 26) is preserved by including both short- and long-form keys in the allowlist.

Unblocks Sch CA kernel auto-derive on the per-line breakdowns it needs to fire in production.

## Why

The Sch CA kernel auto-derive reads `sch_1_line_*` keys directly from `compute_federal` results. Before this branch only the line 10 / line 26 totals were exposed, so per-line California adjustments couldn't fire on the same line breakdowns the IRS Sch 1 PDF carries. This pulls the values from the XLS oracle (path "a" — minimum-blast-radius, no native sch_1.compute changes).

## Changes

- `tenforty/forms/f1040.py` — adds `_ALIASES` (preserves both old + new) for line 10 / line 26 totals; adds `_NUMERIC_SCH_1_KEYS` allowlist with None→0 coercion in `compute()`.
- `tenforty/mappings/f1040.py` — twelve new OUTPUTS entries for Sch 1 Part I + Part II per-line keys; one new SHEET_MAP entry for line 4 direct cell ref.
- `tenforty/oracle/engine.py` — `_read_outputs` falls back to `SHEET_MAP[output_key]` when the OUTPUTS value isn't a named range (mirrors `_write_inputs` behavior). Strictly additive; existing named-range OUTPUTS are unaffected.
- `tests/test_orchestrator_compute_federal_keys.py` — six end-to-end tests through `ReturnOrchestrator` pinning key presence, value coercion, and XLS/native parity for non-K-1 scenarios.
- `tests/test_f1040_mapping.py` — pre-flight merged-cell check now narrowed to keys that appear in INPUTS (output-only SHEET_MAP entries skipped); orphan-key guard preserved.
- `tests/test_engine.py` — covers both branches of the new SHEET_MAP fallback.

## Test plan

- [x] Full pytest suite: `671 passed, 23 skipped in 1179.13s` — no failures, no new skips
- [x] Targeted suite `tests/test_orchestrator_compute_federal_keys.py`: 7/7 pass
- [x] Targeted suite `tests/test_f1040_mapping.py`: 24/24 pass
- [x] Final code review: APPROVED_WITH_NOTES (nits addressed)
- [x] No Iron Law 9 violations in production code or commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)