### PR TITLE
refactor(tests): auto-derive scope_out_attestation_defaults from registry

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 
 from tenforty.models import Scenario, TaxReturnConfig, W2
+from tenforty.attestations import _ATTESTATIONS
 
 REPO_ROOT = Path(__file__).parent.parent
 SPREADSHEETS_DIR = REPO_ROOT / "spreadsheets"
@@ -31,44 +32,31 @@ needs_pdf = unittest.skipUnless(
 )
 
 
-def scope_out_attestation_defaults() -> dict[str, bool]:
-    """Return a dict of safe-default values for every scope-out attestation
-    field (Plan D, K-1, S-corp) on an in-memory test scenario.
+# Test fixtures affirm three attestations as True because they match the
+# common in-memory scenario posture: unlimited at-risk amounts, basis
+# tracked externally, no K-1 credits. Every other registered attestation
+# defaults to False. To change the default for an attestation that
+# already exists, edit this set; new attestations default to False
+# automatically.
+_TEST_POSTURE_AFFIRMED: frozenset[str] = frozenset({
+    "acknowledges_unlimited_at_risk",
+    "basis_tracked_externally",
+    "acknowledges_no_k1_credits",
+})
 
-    Three fields default to True because they affirm the common test posture:
-    unlimited at-risk amounts, basis tracked externally, and no K-1 credits.
-    The other fields stay False because their compute-time gates fire only
-    when the scenario's K-1s or lots actually carry the triggering field
-    value — an all-False default is safe and conservative. Tests that need
-    a different value for one of the three True fields should override it
-    explicitly on `scenario.config`. The 8 1120-S fields are likewise safe
-    at False because their compute gates require `s.s_corp_return` to be
-    non-None."""
+
+def scope_out_attestation_defaults() -> dict[str, bool]:
+    """Return safe-default values for every registered scope-out attestation.
+
+    Auto-derived from `tenforty.attestations._ATTESTATIONS` so that adding
+    a new attestation to the registry requires zero fixture-helper edits
+    when it should default False (the conservative case). Three fields
+    default to True because they affirm the common test posture; see
+    `_TEST_POSTURE_AFFIRMED`. Tests that need a different value for any
+    field should override it explicitly on `scenario.config`."""
     return {
-        "has_foreign_accounts": False,
-        "acknowledges_sch_a_sales_tax_unsupported": False,
-        "acknowledges_qbi_below_threshold": False,
-        "acknowledges_unlimited_at_risk": True,
-        "basis_tracked_externally": True,
-        "acknowledges_no_partnership_se_earnings": False,
-        "acknowledges_no_section_1231_gain": False,
-        "acknowledges_no_more_than_four_k1s": False,
-        "acknowledges_no_k1_credits": True,
-        "acknowledges_no_section_179": False,
-        "acknowledges_no_estate_trust_k1": False,
-        "prior_year_itemized": False,
-        "acknowledges_no_wash_sale_adjustments": False,
-        "acknowledges_no_other_basis_adjustments": False,
-        "acknowledges_no_28_rate_gain": False,
-        "acknowledges_no_unrecaptured_section_1250": False,
-        "acknowledges_no_1120s_schedule_l_needed": False,
-        "acknowledges_no_1120s_schedule_m_needed": False,
-        "acknowledges_constant_shareholder_ownership": False,
-        "acknowledges_no_section_1375_tax": False,
-        "acknowledges_no_section_1374_tax": False,
-        "acknowledges_cogs_aggregate_only": False,
-        "acknowledges_officer_comp_aggregate_only": False,
-        "acknowledges_no_elective_payment_election": False,
+        attestation.field: attestation.field in _TEST_POSTURE_AFFIRMED
+        for attestation in _ATTESTATIONS
     }
 
 

--- a/tests/test_helpers_attestation_defaults.py
+++ b/tests/test_helpers_attestation_defaults.py
@@ -1,0 +1,43 @@
+"""Regression snapshot for the scope-out attestation defaults helper.
+
+The helper is auto-derived from `tenforty.attestations._ATTESTATIONS`, but
+this test pins the exact dict the helper produces today as a hardcoded
+golden value. If a future registry change silently shifts what
+`scope_out_attestation_defaults()` returns, this test fails loudly. The
+hardcoded `True` set documents the three "common test posture" affirmations
+that override the auto-derived `False` default."""
+
+import unittest
+
+from tests.helpers import scope_out_attestation_defaults
+
+
+class ScopeOutAttestationDefaultsSnapshotTests(unittest.TestCase):
+    def test_returns_exact_expected_dict(self):
+        expected = {
+            "has_foreign_accounts": False,
+            "acknowledges_sch_a_sales_tax_unsupported": False,
+            "acknowledges_qbi_below_threshold": False,
+            "acknowledges_unlimited_at_risk": True,
+            "basis_tracked_externally": True,
+            "acknowledges_no_partnership_se_earnings": False,
+            "acknowledges_no_section_1231_gain": False,
+            "acknowledges_no_more_than_four_k1s": False,
+            "acknowledges_no_k1_credits": True,
+            "acknowledges_no_section_179": False,
+            "acknowledges_no_estate_trust_k1": False,
+            "prior_year_itemized": False,
+            "acknowledges_no_wash_sale_adjustments": False,
+            "acknowledges_no_other_basis_adjustments": False,
+            "acknowledges_no_28_rate_gain": False,
+            "acknowledges_no_unrecaptured_section_1250": False,
+            "acknowledges_no_1120s_schedule_l_needed": False,
+            "acknowledges_no_1120s_schedule_m_needed": False,
+            "acknowledges_constant_shareholder_ownership": False,
+            "acknowledges_no_section_1375_tax": False,
+            "acknowledges_no_section_1374_tax": False,
+            "acknowledges_cogs_aggregate_only": False,
+            "acknowledges_officer_comp_aggregate_only": False,
+            "acknowledges_no_elective_payment_election": False,
+        }
+        self.assertEqual(expected, scope_out_attestation_defaults())


### PR DESCRIPTION
## Summary

- Refactor `tests/helpers.scope_out_attestation_defaults()` to auto-derive its keys from `tenforty.attestations._ATTESTATIONS` instead of hand-coding 24 field names.
- Module-level `_TEST_POSTURE_AFFIRMED` frozenset documents the three fields that the common in-memory test scenario affirms as True (unlimited at-risk, basis tracked externally, no K-1 credits). Every other registered attestation defaults False.
- Adds a snapshot regression test (`tests/test_helpers_attestation_defaults.py`) that pins today's exact return value of the helper as a golden dict — guards against silent drift if the registry or affirmed-set ever changes.

Behavior is unchanged: the auto-derived dict equals the previous hardcoded dict exactly (verified by the snapshot test and full-suite IV). Adding a new attestation to the registry now requires zero fixture-helper edits when it should default False; if a new attestation should default True for tests, add its field name to `_TEST_POSTURE_AFFIRMED`.

## Test plan

- [x] Snapshot regression test passes against the refactored helper (1 passed in 0.10s)
- [x] Full pytest suite green: 665 passed, 21 skipped, 961 subtests passed in 890.49s — 0 failures vs. baseline 664/21/0 from main tip 0edb657 (the +1 is the new snapshot test)
- [x] Direct callers of the helper exercised individually (test_scenario, test_orchestrator_predicates, test_orchestrator_emit_pdfs, test_orchestrator_corporate, test_sch_d_compute, test_f8949_oracle, test_scenario_scorp): 97 passed, 2 skipped, 0 failures