### PR TITLE
Add TaxReturnConfig.pdf_header() helper; migrate 11 form modules

### DIFF
--- a/tenforty/forms/f4562.py
+++ b/tenforty/forms/f4562.py
@@ -51,10 +51,7 @@ _PROPERTY_METHOD = {
 
 def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     tax_year = scenario.config.year
-    result: dict = {
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
-    }
+    result: dict = {**scenario.config.pdf_header()}
     assets_by_class: dict[str, list] = defaultdict(list)
     for asset in scenario.depreciable_assets:
         assets_by_class[asset.recovery_class].append(asset)

--- a/tenforty/forms/f8582.py
+++ b/tenforty/forms/f8582.py
@@ -138,6 +138,7 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
             })
 
     return {
+        **scenario.config.pdf_header(),
         "f8582_line_1a_activities_with_income": passive_income_total,
         "f8582_line_1b_activities_with_loss": passive_loss_total,
         "f8582_line_1c_prior_year_unallowed_loss": prior_carryforward_total,
@@ -147,6 +148,4 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "f8582_line_11_allowed_loss": allowed_loss,
         "f8582_special_allowance": allowance,
         "per_activity_carryforwards": per_activity_carryforwards,
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
     }

--- a/tenforty/forms/f8949.py
+++ b/tenforty/forms/f8949.py
@@ -80,10 +80,7 @@ def compute(scenario: Scenario, upstream: UpstreamState) -> dict:
     lots_by_box: dict[str, list[Form8949Lot]] = defaultdict(list)
     for lot in lots:
         lots_by_box[lot.box].append(lot)
-    result: dict = {
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
-    }
+    result: dict = {**scenario.config.pdf_header()}
     for letter in ("a", "b", "c", "d", "e", "f"):
         box_lots = lots_by_box[letter]
         if box_lots and letter in _CHECKBOX_LETTERS:

--- a/tenforty/forms/f8959.py
+++ b/tenforty/forms/f8959.py
@@ -78,8 +78,7 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     line_24 = line_22 + line_23
 
     result: dict = {
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
+        **scenario.config.pdf_header(),
         "f8959_line_1": irs_round(line_1),
         "f8959_line_2": irs_round(line_2),
         "f8959_line_3": irs_round(line_3),

--- a/tenforty/forms/f8995.py
+++ b/tenforty/forms/f8995.py
@@ -55,6 +55,7 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     line_15 = min(line_6, line_14)
 
     return {
+        **scenario.config.pdf_header(),
         "f8995_line_1_qbi": line_1,
         "f8995_line_2_total_qbi": line_2,
         "f8995_line_3_component": line_3,
@@ -66,6 +67,4 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "f8995_line_13_subtract": line_13,
         "f8995_line_14_income_limit": line_14,
         "f8995_line_15_qbi_deduction": line_15,
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
     }

--- a/tenforty/forms/sch_1.py
+++ b/tenforty/forms/sch_1.py
@@ -94,6 +94,7 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     )
 
     return {
+        **scenario.config.pdf_header(),
         "sch_1_line_1_taxable_refunds": taxable_refunds_line_1,
         "sch_1_line_3_business_income": business_income_line_3,
         "sch_1_line_4_other_gains": capital_gain_line_4,
@@ -109,6 +110,4 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "sch_1_line_20_ira": ira_deduction_line_20,
         "sch_1_line_21_student_loan_interest": student_loan_interest_line_21,
         "sch_1_line_26_total_adjustments": total_adjustments_line_26,
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
     }

--- a/tenforty/forms/sch_a.py
+++ b/tenforty/forms/sch_a.py
@@ -106,6 +106,7 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     )
 
     return {
+        **scenario.config.pdf_header(),
         "sch_a_line_1_medical_gross": medical_gross,
         "sch_a_line_2_agi": agi,
         "sch_a_line_3_medical_floor": medical_floor,
@@ -126,6 +127,4 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "sch_a_line_15_casualty": line_15_casualty,
         "sch_a_line_16_other": line_16_other,
         "sch_a_line_17_total": line_17_total,
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
     }

--- a/tenforty/forms/sch_b.py
+++ b/tenforty/forms/sch_b.py
@@ -54,14 +54,13 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     total_dividends = sum(p["amount"] for p in dividend_payers)
 
     return {
+        **scenario.config.pdf_header(),
         "interest_payers": interest_payers,
         "total_interest": total_interest,
         "excludable_savings_bond": 0,
         "taxable_interest": total_interest,
         "dividend_payers": dividend_payers,
         "total_ordinary_dividends": total_dividends,
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
     }
 
 

--- a/tenforty/forms/sch_d.py
+++ b/tenforty/forms/sch_d.py
@@ -37,8 +37,7 @@ def compute(scenario: Scenario, upstream: UpstreamState) -> dict:
     line_16 = line_7 + line_15
 
     return {
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
+        **scenario.config.pdf_header(),
 
         "sch_d_line_1a_proceeds": line_1a["proceeds"],
         "sch_d_line_1a_basis": line_1a["basis"],

--- a/tenforty/forms/sch_e.py
+++ b/tenforty/forms/sch_e.py
@@ -42,10 +42,7 @@ _EXPENSE_FIELDS = (
 
 def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
     f1040 = upstream.get("f1040", {})
-    result: dict = {
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
-    }
+    result: dict = {**scenario.config.pdf_header()}
     if not scenario.rental_properties:
         return result
 

--- a/tenforty/forms/sch_e_part_ii.py
+++ b/tenforty/forms/sch_e_part_ii.py
@@ -56,10 +56,7 @@ def compute(
 ) -> tuple[dict, K1FanoutData]:
     _enforce_scope_gates(scenario)
 
-    result: dict = {
-        "taxpayer_name": scenario.config.full_name,
-        "taxpayer_ssn": scenario.config.ssn,
-    }
+    result: dict = {**scenario.config.pdf_header()}
 
     interest_additions: list[PayerAmount] = []
     dividend_additions: list[PayerAmount] = []

--- a/tenforty/models.py
+++ b/tenforty/models.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from datetime import date as _date
 from enum import Enum
+from types import MappingProxyType
+from typing import Mapping
 
 
 @dataclass
@@ -393,6 +395,12 @@ class TaxReturnConfig:
         first = self.first_name.strip()
         last = self.last_name.strip()
         return f"{first} {last}".strip()
+
+    def pdf_header(self) -> Mapping[str, str]:
+        return MappingProxyType({
+            "taxpayer_name": self.full_name,
+            "taxpayer_ssn": self.ssn,
+        })
 
 
 @dataclass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 import dataclasses
 import unittest
 from pathlib import Path
+from types import MappingProxyType
 
 import tempfile
 
@@ -585,7 +586,6 @@ class TestTaxReturnConfigPdfHeader(unittest.TestCase):
         return TaxReturnConfig(**defaults)
 
     def test_returns_name_and_ssn_keys(self) -> None:
-        from types import MappingProxyType
         cfg = self._config(first_name="Taxpayer", last_name="A", ssn="000-00-3333")
         header = cfg.pdf_header()
         self.assertIsInstance(header, MappingProxyType)
@@ -619,7 +619,7 @@ class TestTaxReturnConfigPdfHeader(unittest.TestCase):
         # Confirms the call-site idiom `{**scenario.config.pdf_header()}`
         # works — `**` reads from any Mapping, mutable or read-only.
         cfg = self._config(first_name="Taxpayer", last_name="A", ssn="000-00-3333")
-        result = {"some_other_key": 42, **cfg.pdf_header()}
+        result = {**cfg.pdf_header(), "some_other_key": 42}
         self.assertEqual(result["taxpayer_name"], "Taxpayer A")
         self.assertEqual(result["taxpayer_ssn"], "000-00-3333")
         self.assertEqual(result["some_other_key"], 42)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -560,6 +560,71 @@ class TestTaxReturnConfigFullName(unittest.TestCase):
         self.assertEqual(cfg.full_name, "Taxpayer")
 
 
+class TestTaxReturnConfigPdfHeader(unittest.TestCase):
+    def _config(self, **kw) -> "TaxReturnConfig":
+        from tenforty.models import TaxReturnConfig
+        defaults = dict(
+            year=2025, filing_status="single", birthdate="1990-06-15", state="CA",
+            has_foreign_accounts=False,
+            acknowledges_sch_a_sales_tax_unsupported=False,
+            acknowledges_qbi_below_threshold=False,
+            acknowledges_unlimited_at_risk=False, basis_tracked_externally=False,
+            acknowledges_no_partnership_se_earnings=False,
+            acknowledges_no_section_1231_gain=False,
+            acknowledges_no_more_than_four_k1s=False,
+            acknowledges_no_k1_credits=False,
+            acknowledges_no_section_179=False,
+            acknowledges_no_estate_trust_k1=False,
+            prior_year_itemized=False,
+            acknowledges_no_wash_sale_adjustments=False,
+            acknowledges_no_other_basis_adjustments=False,
+            acknowledges_no_28_rate_gain=False,
+            acknowledges_no_unrecaptured_section_1250=False,
+        )
+        defaults.update(kw)
+        return TaxReturnConfig(**defaults)
+
+    def test_returns_name_and_ssn_keys(self) -> None:
+        from types import MappingProxyType
+        cfg = self._config(first_name="Taxpayer", last_name="A", ssn="000-00-3333")
+        header = cfg.pdf_header()
+        self.assertIsInstance(header, MappingProxyType)
+        self.assertEqual(header["taxpayer_name"], "Taxpayer A")
+        self.assertEqual(header["taxpayer_ssn"], "000-00-3333")
+        self.assertEqual(set(header.keys()), {"taxpayer_name", "taxpayer_ssn"})
+
+    def test_uses_full_name_stripping(self) -> None:
+        cfg = self._config(first_name="  Taxpayer  ", last_name=" A ", ssn="000-00-3333")
+        self.assertEqual(cfg.pdf_header()["taxpayer_name"], "Taxpayer A")
+
+    def test_empty_name_and_ssn_pass_through(self) -> None:
+        cfg = self._config()
+        header = cfg.pdf_header()
+        self.assertEqual(header["taxpayer_name"], "")
+        self.assertEqual(header["taxpayer_ssn"], "")
+
+    def test_returns_readonly_mapping(self) -> None:
+        # MappingProxyType raises TypeError on any mutation attempt — guards
+        # against a downstream caller accidentally writing into the header.
+        cfg = self._config(first_name="Taxpayer", last_name="A", ssn="000-00-3333")
+        header = cfg.pdf_header()
+        with self.assertRaises(TypeError):
+            header["taxpayer_name"] = "MUTATED"
+        with self.assertRaises(TypeError):
+            del header["taxpayer_name"]
+        # The original mapping is unchanged.
+        self.assertEqual(header["taxpayer_name"], "Taxpayer A")
+
+    def test_unpacks_into_dict_literal(self) -> None:
+        # Confirms the call-site idiom `{**scenario.config.pdf_header()}`
+        # works — `**` reads from any Mapping, mutable or read-only.
+        cfg = self._config(first_name="Taxpayer", last_name="A", ssn="000-00-3333")
+        result = {"some_other_key": 42, **cfg.pdf_header()}
+        self.assertEqual(result["taxpayer_name"], "Taxpayer A")
+        self.assertEqual(result["taxpayer_ssn"], "000-00-3333")
+        self.assertEqual(result["some_other_key"], 42)
+
+
 class TestScheduleK1EntityTypeEnum(unittest.TestCase):
     def test_construct_with_enum_member(self) -> None:
         from tenforty.models import EntityType, ScheduleK1


### PR DESCRIPTION
## Summary
- Add `TaxReturnConfig.pdf_header()` returning a `MappingProxyType` view of `{"taxpayer_name": full_name, "taxpayer_ssn": ssn}` — read-only, raises `TypeError` on mutation.
- Migrate 11 form modules (`sch_1`, `sch_b`, `sch_e_part_ii`, `f8582`, `f4562`, `f8995`, `sch_e`, `sch_a`, `f8959`, `f8949`, `sch_d`) from inline two-line dict literals to `**scenario.config.pdf_header()` unpack.
- Standardize header position: `taxpayer_*` keys are now the **first** entries of every form's compute-output dict, mirroring the IRS form-layout convention (header at the top of the page).
- Single edit point if the PDF-header schema ever changes.

## Test plan
- [x] New `TestTaxReturnConfigPdfHeader` covers read-only enforcement (`MappingProxyType`, `TypeError` on mutation), name stripping, empty defaults, dict-unpack idiom, and the basic happy path.
- [x] Existing per-form compute and PDF-mapping tests are the regression gate; full suite green at IV.