### PR TITLE
refactor(tests): use scope_out_attestation_defaults() in PdfHeader and FullName tests

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ import yaml
 from datetime import date
 
 from tenforty.forms import sch_d as sch_d_module
+from tests.helpers import scope_out_attestation_defaults
 from tenforty.models import (
     DepreciableAsset,
     FilingStatus,
@@ -563,24 +564,9 @@ class TestTaxReturnConfigFullName(unittest.TestCase):
 
 class TestTaxReturnConfigPdfHeader(unittest.TestCase):
     def _config(self, **kw) -> "TaxReturnConfig":
-        from tenforty.models import TaxReturnConfig
         defaults = dict(
             year=2025, filing_status="single", birthdate="1990-06-15", state="CA",
-            has_foreign_accounts=False,
-            acknowledges_sch_a_sales_tax_unsupported=False,
-            acknowledges_qbi_below_threshold=False,
-            acknowledges_unlimited_at_risk=False, basis_tracked_externally=False,
-            acknowledges_no_partnership_se_earnings=False,
-            acknowledges_no_section_1231_gain=False,
-            acknowledges_no_more_than_four_k1s=False,
-            acknowledges_no_k1_credits=False,
-            acknowledges_no_section_179=False,
-            acknowledges_no_estate_trust_k1=False,
-            prior_year_itemized=False,
-            acknowledges_no_wash_sale_adjustments=False,
-            acknowledges_no_other_basis_adjustments=False,
-            acknowledges_no_28_rate_gain=False,
-            acknowledges_no_unrecaptured_section_1250=False,
+            **scope_out_attestation_defaults(),
         )
         defaults.update(kw)
         return TaxReturnConfig(**defaults)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -523,24 +523,9 @@ class TestVoluntaryContribution(unittest.TestCase):
 
 class TestTaxReturnConfigFullName(unittest.TestCase):
     def _config(self, **kw) -> "TaxReturnConfig":
-        from tenforty.models import TaxReturnConfig
         defaults = dict(
             year=2025, filing_status="single", birthdate="1990-06-15", state="CA",
-            has_foreign_accounts=False,
-            acknowledges_sch_a_sales_tax_unsupported=False,
-            acknowledges_qbi_below_threshold=False,
-            acknowledges_unlimited_at_risk=False, basis_tracked_externally=False,
-            acknowledges_no_partnership_se_earnings=False,
-            acknowledges_no_section_1231_gain=False,
-            acknowledges_no_more_than_four_k1s=False,
-            acknowledges_no_k1_credits=False,
-            acknowledges_no_section_179=False,
-            acknowledges_no_estate_trust_k1=False,
-            prior_year_itemized=False,
-            acknowledges_no_wash_sale_adjustments=False,
-            acknowledges_no_other_basis_adjustments=False,
-            acknowledges_no_28_rate_gain=False,
-            acknowledges_no_unrecaptured_section_1250=False,
+            **scope_out_attestation_defaults(),
         )
         defaults.update(kw)
         return TaxReturnConfig(**defaults)


### PR DESCRIPTION
## Summary

Cleans up two `_config()` helpers inside `tests/test_models.py` to use the auto-derived `scope_out_attestation_defaults()` helper (added in #30) instead of hardcoded scope-out-attestation blocks. These were the last hand-maintained attestation lists in `tests/test_models.py`.

- `TestTaxReturnConfigPdfHeader._config()` (commit 22d47b3): drops in-method `from tenforty.models import TaxReturnConfig`; replaces hardcoded `dict(...)` block with `dict(year=2025, filing_status="single", birthdate="1990-06-15", state="CA", **scope_out_attestation_defaults())`.
- `TestTaxReturnConfigFullName._config()` (commit 8a323e5): same substitution. (The class already had `TaxReturnConfig` imported at the top of the file, so no extra import shuffling here.)
- Adds the import `from tests.helpers import scope_out_attestation_defaults` at the top of the file (used by both classes).

## Behavior note (slight divergence from review brief)

The original review brief said "the helper returns the same dict the explicit block hardcodes." That's not quite right today — the registry has grown since the explicit blocks were written:

- Hardcoded blocks: 16 attestations, all `False`.
- `scope_out_attestation_defaults()`: **24** attestations; 3 of them default to `True` per `_TEST_POSTURE_AFFIRMED` (`acknowledges_unlimited_at_risk`, `basis_tracked_externally`, `acknowledges_no_k1_credits`).

The 3 boolean flips and 8 added attestations have no effect on either test class's assertions:
- `TestTaxReturnConfigPdfHeader` probes `taxpayer_name` / `taxpayer_ssn` / `MappingProxyType` semantics only.
- `TestTaxReturnConfigFullName` probes `full_name` construction only.

All 57 tests in `test_models.py` continue to pass.

## Test plan

- [x] `pytest tests/test_models.py -v` — 57 passed (same count as baseline before edit).
- [x] `pytest tests/test_models.py::TestTaxReturnConfigPdfHeader -v` — all pass.
- [x] `pytest tests/test_models.py::TestTaxReturnConfigFullName -v` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)