### PR TITLE
refactor: extract PdfFormMapping base class

### DIFF
--- a/tenforty/mappings/pdf_1040.py
+++ b/tenforty/mappings/pdf_1040.py
@@ -9,9 +9,13 @@ Field names use the full path format:
     topmostSubform[0].Page1[0].f1_47[0]
 """
 
+from tenforty.mappings.registry import PdfFormMapping
 
-class Pdf1040:
+
+class Pdf1040(PdfFormMapping[dict[str, str]]):
     """PDF field mapping for IRS Form 1040."""
+
+    _FORM_NAME = "Form 1040"
 
     _MAPPINGS: dict[int, dict[str, str]] = {
         2025: {
@@ -160,8 +164,3 @@ class Pdf1040:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict[str, str]:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_4562.py
+++ b/tenforty/mappings/pdf_4562.py
@@ -26,6 +26,8 @@ where `base` is the first f1_N for that row — this module encodes the
 base explicitly rather than relying on arithmetic.
 """
 
+from tenforty.mappings.registry import PdfFormMapping
+
 _P1 = "topmostSubform[0].Page1[0]"
 _P2 = "topmostSubform[0].Page2[0]"
 _SB = f"{_P1}.SectionBTable[0]"
@@ -71,7 +73,9 @@ def _all_row_fields() -> dict[str, str]:
     return out
 
 
-class Pdf4562:
+class Pdf4562(PdfFormMapping[dict]):
+    _FORM_NAME = "Form 4562"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": {
@@ -84,8 +88,3 @@ class Pdf4562:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Form 4562 PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_4868.py
+++ b/tenforty/mappings/pdf_4868.py
@@ -13,9 +13,13 @@ Probe methodology: each text field was filled with its short name (e.g.
 position on the rendered page was matched to the printed label.
 """
 
+from tenforty.mappings.registry import PdfFormMapping
 
-class Pdf4868:
+
+class Pdf4868(PdfFormMapping[dict[str, str]]):
     """PDF field mapping for IRS Form 4868 (Automatic Extension)."""
+
+    _FORM_NAME = "Form 4868"
 
     # Note on checkboxes: c1_1 and c1_2 are /Btn (checkbox) fields.
     # PdfFiller currently writes text values only; checkbox /Btn fields
@@ -70,8 +74,3 @@ class Pdf4868:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict[str, str]:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_8959.py
+++ b/tenforty/mappings/pdf_8959.py
@@ -6,8 +6,12 @@ the header name, f1_2 is the SSN, f1_3..f1_26 map to lines 1..24 in
 order.
 """
 
+from tenforty.mappings.registry import PdfFormMapping
 
-class Pdf8959:
+
+class Pdf8959(PdfFormMapping[dict]):
+    _FORM_NAME = "Form 8959"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": {
@@ -23,8 +27,3 @@ class Pdf8959:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Form 8959 PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_f1120s.py
+++ b/tenforty/mappings/pdf_f1120s.py
@@ -16,86 +16,7 @@ docs/plans/t14-f1120s-probe.md for the per-line rationale.
 """
 
 from collections.abc import Callable, Mapping
-
-
-class PdfF1120S:
-    """PDF field mapping for IRS Form 1120-S.
-
-    Unlike `Pdf1040`, which uses a single flat compute-key → PDF-field
-    dict, this class exposes a five-registry design because the 2025
-    Form 1120-S has structural patterns that a flat map cannot express:
-
-    - `_MAPPING_<year>` — direct 1:1 compute-key → PDF-field-path. Most
-      keys live here. This is the same shape as `Pdf1040._MAPPINGS`.
-    - `_AGGREGATIONS_<year>` — PDF cells that receive the *sum* of
-      multiple compute keys. The 2025 form combined former lines 23a +
-      23b into a single line-24a cell, and the §453 deferred-interest
-      amount must be folded into the line-23c "Total tax" write-in
-      because no separate fillable cell exists.
-    - `_DERIVATIONS_<year>` — PDF cells whose value is *computed* from
-      compute outputs (e.g., line 28b refund = overpayment − credited).
-      These never receive a single compute key directly.
-    - `_SUPPRESSED_<year>` — compute keys that have *no* fillable cell
-      on the year's form. v1 declares them out-of-scope-for-PDF and
-      relies on attestations to ensure the user reports them externally.
-    - `_CHECKBOX_STATES_<year>` — for boolean compute keys whose target
-      PDF cell is an IRS XFA checkbox, this maps the compute key to the
-      per-field "on" appearance state name (e.g. `"/1"`, `"/2"`, `"/3"`)
-      because IRS XFA forms use non-conventional state names rather than
-      the usual `"/Yes"`.
-
-    These extensions did not exist for F1040 because the 1040's PDF
-    fields line up 1:1 with compute outputs at the keys we expose. They
-    are necessary for 1120-S because the IRS reorganized the Tax and
-    Payments section on the 2025 revision (consolidating cells, dropping
-    the built-in-gains-tax line, and converting some former cells into
-    write-in adjustments).
-
-    The partition invariant (enforced by the mapping test) is that every
-    expected compute key is OWNED by exactly one of `_MAPPING_<year>`,
-    `_AGGREGATIONS_<year>`, or `_SUPPRESSED_<year>`. Derivations consume
-    compute keys but do not own them; see the comment block above
-    `_DERIVATIONS_2025` for the convention.
-    """
-
-    @classmethod
-    def get_mapping(cls, year: int) -> dict[str, str]:
-        if year == 2025:
-            return _MAPPING_2025
-        raise ValueError(f"No Form 1120-S mapping for year {year}")
-
-    @classmethod
-    def get_aggregations(cls, year: int) -> dict[str, tuple[str, ...]]:
-        if year == 2025:
-            return _AGGREGATIONS_2025
-        raise ValueError(f"No Form 1120-S aggregations for year {year}")
-
-    @classmethod
-    def get_derivations(
-        cls,
-        year: int,
-    ) -> dict[str, Callable[[Mapping[str, object]], object]]:
-        if year == 2025:
-            return _DERIVATIONS_2025
-        raise ValueError(f"No Form 1120-S derivations for year {year}")
-
-    @classmethod
-    def get_suppressed(cls, year: int) -> frozenset[str]:
-        if year == 2025:
-            return _SUPPRESSED_2025
-        raise ValueError(f"No Form 1120-S suppressions for year {year}")
-
-    @classmethod
-    def get_checkbox_states(cls, year: int) -> dict[str, str]:
-        """Return compute key → PDF "on" state for IRS XFA checkbox fields.
-
-        IRS XFA forms use per-field state names ("/1", "/2", "/3") rather than
-        the conventional "/Yes". These overrides are passed to PdfFiller.fill()
-        so that bool compute keys toggle the correct appearance state.
-        """
-        if year == 2025:
-            return _CHECKBOX_STATES_2025
-        raise ValueError(f"No Form 1120-S checkbox states for year {year}")
+from tenforty.mappings.registry import PdfFormMapping
 
 
 # Direct 1:1 mappings — most compute keys go here.
@@ -174,6 +95,83 @@ _MAPPING_2025: dict[str, str] = {
     "f1120s_sch_k_investment_income":           "topmostSubform[0].Page4[0].f4_1[0]",
     "f1120s_sch_k_income_loss_reconciliation":  "topmostSubform[0].Page4[0].f4_4[0]",
 }
+
+
+class PdfF1120S(PdfFormMapping[dict[str, str]]):
+    """PDF field mapping for IRS Form 1120-S.
+
+    Unlike `Pdf1040`, which uses a single flat compute-key → PDF-field
+    dict, this class exposes a five-registry design because the 2025
+    Form 1120-S has structural patterns that a flat map cannot express:
+
+    - `_MAPPING_<year>` — direct 1:1 compute-key → PDF-field-path. Most
+      keys live here. This is the same shape as `Pdf1040._MAPPINGS`.
+    - `_AGGREGATIONS_<year>` — PDF cells that receive the *sum* of
+      multiple compute keys. The 2025 form combined former lines 23a +
+      23b into a single line-24a cell, and the §453 deferred-interest
+      amount must be folded into the line-23c "Total tax" write-in
+      because no separate fillable cell exists.
+    - `_DERIVATIONS_<year>` — PDF cells whose value is *computed* from
+      compute outputs (e.g., line 28b refund = overpayment − credited).
+      These never receive a single compute key directly.
+    - `_SUPPRESSED_<year>` — compute keys that have *no* fillable cell
+      on the year's form. v1 declares them out-of-scope-for-PDF and
+      relies on attestations to ensure the user reports them externally.
+    - `_CHECKBOX_STATES_<year>` — for boolean compute keys whose target
+      PDF cell is an IRS XFA checkbox, this maps the compute key to the
+      per-field "on" appearance state name (e.g. `"/1"`, `"/2"`, `"/3"`)
+      because IRS XFA forms use non-conventional state names rather than
+      the usual `"/Yes"`.
+
+    These extensions did not exist for F1040 because the 1040's PDF
+    fields line up 1:1 with compute outputs at the keys we expose. They
+    are necessary for 1120-S because the IRS reorganized the Tax and
+    Payments section on the 2025 revision (consolidating cells, dropping
+    the built-in-gains-tax line, and converting some former cells into
+    write-in adjustments).
+
+    The partition invariant (enforced by the mapping test) is that every
+    expected compute key is OWNED by exactly one of `_MAPPING_<year>`,
+    `_AGGREGATIONS_<year>`, or `_SUPPRESSED_<year>`. Derivations consume
+    compute keys but do not own them; see the comment block above
+    `_DERIVATIONS_2025` for the convention.
+    """
+
+    _FORM_NAME = "Form 1120-S"
+    _MAPPINGS: dict[int, dict[str, str]] = {2025: _MAPPING_2025}
+
+    @classmethod
+    def get_aggregations(cls, year: int) -> dict[str, tuple[str, ...]]:
+        if year == 2025:
+            return _AGGREGATIONS_2025
+        raise ValueError(f"No Form 1120-S aggregations for year {year}")
+
+    @classmethod
+    def get_derivations(
+        cls,
+        year: int,
+    ) -> dict[str, Callable[[Mapping[str, object]], object]]:
+        if year == 2025:
+            return _DERIVATIONS_2025
+        raise ValueError(f"No Form 1120-S derivations for year {year}")
+
+    @classmethod
+    def get_suppressed(cls, year: int) -> frozenset[str]:
+        if year == 2025:
+            return _SUPPRESSED_2025
+        raise ValueError(f"No Form 1120-S suppressions for year {year}")
+
+    @classmethod
+    def get_checkbox_states(cls, year: int) -> dict[str, str]:
+        """Return compute key → PDF "on" state for IRS XFA checkbox fields.
+
+        IRS XFA forms use per-field state names ("/1", "/2", "/3") rather than
+        the conventional "/Yes". These overrides are passed to PdfFiller.fill()
+        so that bool compute keys toggle the correct appearance state.
+        """
+        if year == 2025:
+            return _CHECKBOX_STATES_2025
+        raise ValueError(f"No Form 1120-S checkbox states for year {year}")
 
 
 # PDF cells that receive a sum of multiple compute keys.

--- a/tenforty/mappings/pdf_f1120s_k1.py
+++ b/tenforty/mappings/pdf_f1120s_k1.py
@@ -1,19 +1,6 @@
 """PDF field mapping for IRS 2025 Schedule K-1 (Form 1120-S)."""
 
-
-class PdfF1120SK1:
-    """PDF field mapping for IRS Schedule K-1 (Form 1120-S).
-
-    Single flat registry — Schedule K-1 is a single-page form with a 1:1
-    correspondence between K1Allocation fields and PDF cells (no combined
-    cells, no derivations, no structural suppressions). Matches the
-    `Pdf1040` flat-mapping precedent."""
-
-    @classmethod
-    def get_mapping(cls, year: int) -> dict[str, str]:
-        if year == 2025:
-            return _MAPPING_2025
-        raise ValueError(f"No Sch K-1 mapping for year {year}")
+from tenforty.mappings.registry import PdfFormMapping
 
 
 _MAPPING_2025: dict[str, str] = {
@@ -39,3 +26,15 @@ _MAPPING_2025: dict[str, str] = {
         "topmostSubform[0].Page1[0].RightCol[0].Lines1-12[0].f1_21[0]"
     ),
 }
+
+
+class PdfF1120SK1(PdfFormMapping[dict[str, str]]):
+    """PDF field mapping for IRS Schedule K-1 (Form 1120-S).
+
+    Single flat registry — Schedule K-1 is a single-page form with a 1:1
+    correspondence between K1Allocation fields and PDF cells (no combined
+    cells, no derivations, no structural suppressions). Matches the
+    `Pdf1040` flat-mapping precedent."""
+
+    _FORM_NAME = "Schedule K-1 (Form 1120-S)"
+    _MAPPINGS: dict[int, dict[str, str]] = {2025: _MAPPING_2025}

--- a/tenforty/mappings/pdf_f8582.py
+++ b/tenforty/mappings/pdf_f8582.py
@@ -33,8 +33,12 @@ Field names enumerated from ``pdfs/federal/2025/f8582.pdf``:
   f1_19  Line 11 — allowed loss
 """
 
+from tenforty.mappings.registry import PdfFormMapping
 
-class PdfF8582:
+
+class PdfF8582(PdfFormMapping[dict]):
+    _FORM_NAME = "Form 8582"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": {
@@ -52,8 +56,3 @@ class PdfF8582:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Form 8582 PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_f8949.py
+++ b/tenforty/mappings/pdf_f8949.py
@@ -19,6 +19,8 @@ copy of the page for each box.
 import enum
 from dataclasses import dataclass
 
+from tenforty.mappings.registry import PdfFormMapping
+
 
 _COL_NAMES: tuple[str, ...] = (
     "description",
@@ -129,7 +131,9 @@ def _build_scalars_2025() -> dict[str, str]:
     return scalars
 
 
-class PdfF8949:
+class PdfF8949(PdfFormMapping[dict]):
+    _FORM_NAME = "Form 8949"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": _build_scalars_2025(),
@@ -140,8 +144,3 @@ class PdfF8949:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Form 8949 PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_f8995.py
+++ b/tenforty/mappings/pdf_f8995.py
@@ -26,8 +26,12 @@ Field names enumerated from ``pdfs/federal/2025/f8995.pdf``:
   f1_33  Line 17 (net QBI loss carryforward — zero in v1)
 """
 
+from tenforty.mappings.registry import PdfFormMapping
 
-class PdfF8995:
+
+class PdfF8995(PdfFormMapping[dict]):
+    _FORM_NAME = "Form 8995"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": {
@@ -62,8 +66,3 @@ class PdfF8995:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Form 8995 PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_sch_1.py
+++ b/tenforty/mappings/pdf_sch_1.py
@@ -11,11 +11,15 @@ mapping (amount column x≈504, rows top-to-bottom) determined which
 f1_NN/f2_NN field corresponds to which IRS line number.
 """
 
+from tenforty.mappings.registry import PdfFormMapping
+
 _PAGE1 = "topmostSubform[0].Page1[0]"
 _PAGE2 = "topmostSubform[0].Page2[0]"
 
 
-class PdfSch1:
+class PdfSch1(PdfFormMapping[dict]):
+    _FORM_NAME = "Schedule 1"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": {
@@ -43,8 +47,3 @@ class PdfSch1:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Schedule 1 PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_sch_a.py
+++ b/tenforty/mappings/pdf_sch_a.py
@@ -6,10 +6,14 @@ column amount cells (x≈504) are the line-totals (4, 7, 10, 14, 17);
 the left-column x≈410 cells carry individual subparts.
 """
 
+from tenforty.mappings.registry import PdfFormMapping
+
 _PAGE1 = "form1[0].Page1[0]"
 
 
-class PdfSchA:
+class PdfSchA(PdfFormMapping[dict]):
+    _FORM_NAME = "Schedule A"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": {
@@ -45,8 +49,3 @@ class PdfSchA:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Schedule A PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_sch_b.py
+++ b/tenforty/mappings/pdf_sch_b.py
@@ -31,6 +31,8 @@ Assignment (2025):
     f1_66 = Line 6 (sum)
 """
 
+from tenforty.mappings.registry import PdfFormMapping
+
 _PAGE1 = "topmostSubform[0].Page1[0]"
 
 # Row 1's payer field is namespaced inside Line1_ReadOrder; all other
@@ -94,15 +96,10 @@ def _build_2025_mapping() -> dict[str, str]:
     return m
 
 
-class PdfSchB:
+class PdfSchB(PdfFormMapping[dict[str, str]]):
     """PDF field mapping for IRS Schedule B (2025)."""
 
+    _FORM_NAME = "Schedule B"
     _MAPPINGS: dict[int, dict[str, str]] = {
         2025: _build_2025_mapping(),
     }
-
-    @classmethod
-    def get_mapping(cls, year: int) -> dict[str, str]:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Schedule B PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_sch_d.py
+++ b/tenforty/mappings/pdf_sch_d.py
@@ -39,8 +39,12 @@ repeater-aware filler call; the repeaters block is empty because Sch D
 writes scalar cells only.
 """
 
+from tenforty.mappings.registry import PdfFormMapping
 
-class PdfSchD:
+
+class PdfSchD(PdfFormMapping[dict]):
+    _FORM_NAME = "Schedule D"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": {
@@ -179,8 +183,3 @@ class PdfSchD:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Schedule D PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/pdf_sch_e.py
+++ b/tenforty/mappings/pdf_sch_e.py
@@ -25,6 +25,8 @@ Page 2 field discovery notes (2025 form):
   - Line 41 total pass-through (f2_76).
 """
 
+from tenforty.mappings.registry import PdfFormMapping
+
 _P2 = "topmostSubform[0].Page2[0]"
 _T28AF = f"{_P2}.Table_Line28a-f[0]"
 _T28GK = f"{_P2}.Table_Line28g-k[0]"
@@ -61,7 +63,9 @@ def _row_mapping(row_letter: str) -> dict[str, str]:
     }
 
 
-class PdfSchE:
+class PdfSchE(PdfFormMapping[dict]):
+    _FORM_NAME = "Schedule E"
+
     _MAPPINGS: dict[int, dict] = {
         2025: {
             "scalars": {
@@ -183,8 +187,3 @@ class PdfSchE:
         },
     }
 
-    @classmethod
-    def get_mapping(cls, year: int) -> dict:
-        if year not in cls._MAPPINGS:
-            raise ValueError(f"No Schedule E PDF mapping for year {year}")
-        return cls._MAPPINGS[year]

--- a/tenforty/mappings/registry.py
+++ b/tenforty/mappings/registry.py
@@ -24,3 +24,29 @@ class FormMapping:
         if base_year not in base:
             raise ValueError(f"No {source} mapping for year {base_year} in {cls.__name__}")
         return {**base[base_year], **overrides}
+
+
+class PdfFormMapping[MappingT]:
+    """Base class for PDF field mappings keyed by tax year.
+
+    Subclasses declare two class attributes:
+
+    - ``_FORM_NAME`` — display name interpolated into the unknown-year
+      error (e.g. ``"Schedule B"``, ``"Form 1040"``).
+    - ``_MAPPINGS`` — dict mapping tax year to the form's per-year
+      mapping payload. The payload type is subclass-defined; ``MappingT``
+      is the type parameter so subclasses can express it precisely
+      (e.g. ``dict[str, str]`` for flat 1:1 mappings, or richer shapes
+      for forms that partition their payload into scalars and repeaters).
+    """
+
+    _FORM_NAME: str
+    _MAPPINGS: dict[int, MappingT]
+
+    @classmethod
+    def get_mapping(cls, year: int) -> MappingT:
+        if year not in cls._MAPPINGS:
+            raise ValueError(
+                f"No {cls._FORM_NAME} PDF mapping for year {year}"
+            )
+        return cls._MAPPINGS[year]

--- a/tests/test_pdf_form_mapping_base.py
+++ b/tests/test_pdf_form_mapping_base.py
@@ -1,0 +1,48 @@
+"""Behavior tests for the PdfFormMapping base class."""
+
+import unittest
+
+from tenforty.mappings.registry import PdfFormMapping
+
+
+class _FlatTestMapping(PdfFormMapping[dict[str, str]]):
+    _FORM_NAME = "Test Flat"
+    _MAPPINGS: dict[int, dict[str, str]] = {
+        2024: {"a": "x"},
+        2025: {"a": "y"},
+    }
+
+
+class _RichTestMapping(PdfFormMapping[dict]):
+    _FORM_NAME = "Test Rich"
+    _MAPPINGS: dict[int, dict] = {
+        2025: {"scalars": {"k": "v"}, "repeaters": {}},
+    }
+
+
+class PdfFormMappingTests(unittest.TestCase):
+    def test_get_mapping_returns_payload_for_known_year(self):
+        self.assertEqual(_FlatTestMapping.get_mapping(2024), {"a": "x"})
+        self.assertEqual(_FlatTestMapping.get_mapping(2025), {"a": "y"})
+
+    def test_get_mapping_unknown_year_raises_with_form_name(self):
+        with self.assertRaisesRegex(
+            ValueError, "No Test Flat PDF mapping for year 1999"
+        ):
+            _FlatTestMapping.get_mapping(1999)
+
+    def test_get_mapping_supports_arbitrary_value_shape(self):
+        result = _RichTestMapping.get_mapping(2025)
+        self.assertIn("scalars", result)
+        self.assertIn("repeaters", result)
+        self.assertEqual(result["scalars"], {"k": "v"})
+
+    def test_get_mapping_unknown_year_includes_year_in_message(self):
+        with self.assertRaisesRegex(
+            ValueError, "year 9999"
+        ):
+            _RichTestMapping.get_mapping(9999)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extracts a generic `PdfFormMapping[MappingT]` base class to `tenforty/mappings/registry.py` and migrates all 14 existing PDF mapping modules to use it. Removes ~10 lines of identical `get_mapping` + `_MAPPINGS + raise ValueError` boilerplate per file (140+ lines repo-wide), and standardizes the unknown-year error message format.

## What

New base class (PEP 695 generic syntax):

```python
class PdfFormMapping[MappingT]:
    _FORM_NAME: str
    _MAPPINGS: dict[int, MappingT]

    @classmethod
    def get_mapping(cls, year: int) -> MappingT:
        if year not in cls._MAPPINGS:
            raise ValueError(f"No {cls._FORM_NAME} PDF mapping for year {year}")
        return cls._MAPPINGS[year]
```

Each subclass declares a `_FORM_NAME` string and inherits `get_mapping` for free:

```python
class Pdf1040(PdfFormMapping[dict[str, str]]):
    _FORM_NAME = "Form 1040"
    _MAPPINGS: dict[int, dict[str, str]] = {2025: {...}}
```

## Migrated modules (14)

Flat (`dict[str, str]`):
- `pdf_1040.py`, `pdf_sch_b.py`, `pdf_f1120s_k1.py`, `pdf_f1120s.py`

Rich (`dict` — repeaters / spec subclasses):
- `pdf_4868.py`, `pdf_4562.py`, `pdf_8959.py`, `pdf_f8582.py`, `pdf_f8949.py`, `pdf_f8995.py`, `pdf_sch_1.py`, `pdf_sch_a.py`, `pdf_sch_d.py`, `pdf_sch_e.py`

For `pdf_f1120s_k1.py` and `pdf_f1120s.py` the migration also restructures the module-level `_MAPPING_2025` constant to live BEFORE the class so it can be referenced at class-body scope.

## Scope

This PR refactors only the `get_mapping` accessor — the standardized year-keyed lookup. The four additional registries on `PdfF1120S` (`get_aggregations`, `get_derivations`, `get_suppressed`, `get_checkbox_states`) are intentionally **out of scope** and left byte-identical. They are a distinct per-registry-accessor pattern; a future PR can extract a base abstraction for them if there is appetite.

## Error-message standardization

Each `_FORM_NAME` is chosen to satisfy every existing `assertRaisesRegex` in the test suite without requiring a single test edit:

| Module | `_FORM_NAME` | Existing test regex |
|---|---|---|
| `pdf_1040` | `"Form 1040"` | (bare `assertRaises`) |
| `pdf_4868` | `"Form 4868"` | `"1999"` |
| `pdf_4562` | `"Form 4562"` | `"No Form 4562 PDF mapping"` |
| `pdf_8959` | `"Form 8959"` | `"8959"` |
| `pdf_f8582` | `"Form 8582"` | (bare `assertRaises`) |
| `pdf_f8949` | `"Form 8949"` | (bare `assertRaises`) |
| `pdf_f8995` | `"Form 8995"` | (bare `assertRaises`) |
| `pdf_sch_1` | `"Schedule 1"` | matches `"Schedule 1"` |
| `pdf_sch_a` | `"Schedule A"` | matches `"Schedule A"` |
| `pdf_sch_b` | `"Schedule B"` | matches `"Schedule B"` |
| `pdf_sch_d` | `"Schedule D"` | matches `"Schedule D"` |
| `pdf_sch_e` | `"Schedule E"` | matches `"Schedule E"` |
| `pdf_f1120s` | `"Form 1120-S"` | (no existing regex) |
| `pdf_f1120s_k1` | `"Schedule K-1 (Form 1120-S)"` | (no existing regex) |

## Test plan

- [x] 4 new unit tests in `tests/test_pdf_form_mapping_base.py` cover the base class itself: known-year payload return, unknown-year `ValueError` with `_FORM_NAME` interpolated, arbitrary `MappingT` value shape.
- [x] All 14 per-module test files run green after migration (`pytest tests/test_pdf_*_mapping.py tests/test_4562_round_trip.py`).
- [x] Full suite: `682 passed, 21 skipped` (delta from main baseline at f626924: collect-only count went 699 → 703, exactly +4 from the new base-class tests; pass delta is the same +4). No test edits were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)