### PR TITLE
chore: small cleanup pass — datetime imports, PDF-field uniqueness, render reconciliation

### DIFF
--- a/tenforty/filing/pdf.py
+++ b/tenforty/filing/pdf.py
@@ -109,15 +109,6 @@ class PdfFiller:
         return output_path
 
     @staticmethod
-    def _render(value) -> str:
-        """Stringify a scalar value for PDF field writing (mirrors existing fill logic)."""
-        if isinstance(value, bool):
-            return "Yes" if value else "Off"
-        if isinstance(value, (int, float)):
-            return str(value)
-        return str(value)
-
-    @staticmethod
     def _expand_repeaters(mapping: dict, values: dict) -> dict[str, str]:
         """Flatten a {scalars, repeaters} mapping + values into a flat field dict.
 
@@ -131,7 +122,7 @@ class PdfFiller:
         for result_key, pdf_field in mapping.get("scalars", {}).items():
             v = values.get(result_key)
             if v is not None:
-                flat[pdf_field] = PdfFiller._render(v)
+                flat[pdf_field] = PdfFiller._render_scalar(v)
 
         for section_name, section in mapping.get("repeaters", {}).items():
             rows = values.get(section_name) or []
@@ -153,7 +144,7 @@ class PdfFiller:
                     v = row.get(inner_key)
                     if v is not None:
                         field = template.replace("{i}", str(i))
-                        flat[field] = PdfFiller._render(v)
+                        flat[field] = PdfFiller._render_scalar(v)
         return flat
 
     def fill_with_repeaters(

--- a/tenforty/forms/sch_a.py
+++ b/tenforty/forms/sch_a.py
@@ -112,7 +112,23 @@ def compute(scenario: Scenario, upstream: dict[str, dict]) -> dict:
         "sch_a_line_3_medical_floor": medical_floor,
         "sch_a_line_4_medical_deductible": medical_deductible,
         "sch_a_line_5a_state_income_tax": state_income_tax_line_5a,
-        "sch_a_line_5a_sales_tax_checkbox": False,
+        # sch_a_line_5a_sales_tax_checkbox is intentionally omitted here.
+        #
+        # Today there is no compute path that drives this checkbox True — the
+        # sales-tax election is out of scope for v1 (see module docstring).
+        # Emitting `False` would route through fill_with_repeaters's scalar
+        # path, which (before the _render → _render_scalar unification in this
+        # commit) silently coerced the bool via _render's "Off" branch instead
+        # of going through the project-required checkbox_states registry. That
+        # was a latent policy bypass.
+        #
+        # When a future implementation adds the sales-tax election:
+        #   • emit True only when the filer actually elects sales tax;
+        #   • add a _CHECKBOX_STATES registry entry on pdf_sch_a (see
+        #     tenforty/filing/pdf_sch_a.py) so the value is routed through
+        #     the checkbox-state-aware fill path;
+        #   • do NOT re-introduce a bare True/False literal in this dict,
+        #     because _render_scalar now raises on bool to enforce that policy.
         "sch_a_line_5b_property_tax": property_tax_line_5b,
         "sch_a_line_5c_personal_property_tax": personal_property_tax_line_5c,
         "sch_a_line_5d_salt_sum": line_5d,

--- a/tenforty/models.py
+++ b/tenforty/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import date as _date
+from datetime import date
 from enum import Enum
 from types import MappingProxyType
 from typing import Mapping
@@ -438,11 +438,11 @@ class DepreciableAsset:
     """
 
     description: str
-    date_placed_in_service: _date
+    date_placed_in_service: date
     basis: float
     recovery_class: str
     convention: str
-    disposed: _date | None = None
+    disposed: date | None = None
 
 
 @dataclass
@@ -556,8 +556,8 @@ class SCorpReturn:
     name: str
     ein: str
     address: Address
-    date_incorporated: _date
-    s_election_effective_date: _date
+    date_incorporated: date
+    s_election_effective_date: date
 
     income: SCorpIncome
     deductions: SCorpDeductions

--- a/tests/test_pdf_field_path_uniqueness.py
+++ b/tests/test_pdf_field_path_uniqueness.py
@@ -1,0 +1,245 @@
+"""Invariant test: intra-section uniqueness of PDF field paths across every
+PdfFormMapping subclass and every year.
+
+The invariant: within a single addressable scope, no two compute keys may
+map to the same PDF field path.  "Addressable scope" is:
+  - The scalars dict (or the entire flat payload for flat-shaped modules).
+  - Each individual repeater section (box_a_rows, box_b_rows, etc.).
+
+We intentionally do NOT cross-check between sections; paginated multi-emission
+forms legitimately reuse paths across sections (e.g. box_a_rows and box_b_rows
+in Form 8949 share page-1 table paths — they are emitted into separate physical
+PDF copies).
+"""
+
+import importlib
+import pkgutil
+import unittest
+from collections import Counter
+from typing import Any
+
+import tenforty.mappings as _mappings_pkg
+from tenforty.mappings.pdf_f8949 import PdfF8949
+from tenforty.mappings.registry import PdfFormMapping
+
+# ---------------------------------------------------------------------------
+# Allowlist of intentionally shared scalar PDF field paths, keyed by class.
+#
+# PdfF8949 architecture (see tenforty/mappings/pdf_f8949.py:10-16):
+#   Form 8949 uses one shared repeater table per page.  Boxes A and B both
+#   live on page 1; boxes D and E both live on page 2.  The filler emits a
+#   separate physical PDF copy of the page for each box, writing the
+#   appropriate checkbox and totals once per copy.  Consequently, the four
+#   page-level totals scalars (total_proceeds, total_basis, total_adjustment,
+#   total_gain) on page 1 are shared between the box_a_* and box_b_* compute
+#   keys, and the same four on page 2 are shared between box_d_* and box_e_*.
+#   This yields exactly 8 intentionally shared scalar paths — all of them
+#   totals fields.  Checkboxes are NOT shared (they use different array
+#   indices: c{page}_1[0] vs c{page}_1[1]).
+# ---------------------------------------------------------------------------
+
+def _derive_f8949_shared_paths() -> frozenset[str]:
+    """Return the frozenset of scalar paths that appear more than once in
+    PdfF8949._MAPPINGS[2025]['scalars'].  Used to build the allowlist from
+    the live source so the constant stays in sync automatically."""
+    scalars: dict[str, str] = PdfF8949._MAPPINGS[2025]["scalars"]
+    counts = Counter(scalars.values())
+    return frozenset(path for path, count in counts.items() if count > 1)
+
+
+_KNOWN_SHARED_PATHS: dict[type, frozenset[str]] = {
+    PdfF8949: _derive_f8949_shared_paths(),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers: discover subclasses and iterate scopes
+# ---------------------------------------------------------------------------
+
+def _discover_pdf_mapping_classes() -> list[type]:
+    """Import every module under tenforty.mappings and return all concrete
+    PdfFormMapping subclasses (direct or indirect) found in those modules."""
+    # Walk the package so new modules are picked up automatically.
+    for _finder, name, _ispkg in pkgutil.walk_packages(
+        path=_mappings_pkg.__path__,
+        prefix=_mappings_pkg.__name__ + ".",
+    ):
+        importlib.import_module(name)
+
+    # Collect all subclasses via __subclasses__ recursively.
+    def _collect(cls: type) -> list[type]:
+        result = []
+        for sub in cls.__subclasses__():
+            result.append(sub)
+            result.extend(_collect(sub))
+        return result
+
+    all_subs = _collect(PdfFormMapping)
+    # Exclude private test-only helpers (defined in test files / registry tests).
+    return [
+        cls for cls in all_subs
+        if cls.__module__.startswith("tenforty.")
+    ]
+
+
+def _iter_scopes(
+    cls: type, year: int, payload: Any
+) -> list[tuple[str, dict[str, str]]]:
+    """Return a list of (scope_name, {compute_key: pdf_path}) pairs.
+
+    Handles two payload shapes:
+    1. Flat dict[str, str] — the whole dict is one scope named "scalars".
+    2. {"scalars": dict, "repeaters": dict} — scalars is one scope; each
+       repeater section is a separate scope.
+
+    Repeater section sub-shapes:
+    - list[dict[str, str]]: list of already-expanded row dicts (PdfF8949).
+      Merge all rows into a flat dict for the scope; duplicate path detection
+      still applies within the section.
+    - dict with "template" key: template-based (not currently present in the
+      codebase, but handled for forward-compat).
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(
+            f"{cls.__name__}[{year}]: unexpected payload type {type(payload)}"
+        )
+
+    # Detect flat vs structured shape by checking for "scalars" key.
+    if "scalars" in payload or "repeaters" in payload:
+        scopes: list[tuple[str, dict[str, str]]] = []
+
+        scalars = payload.get("scalars", {})
+        if scalars:
+            scopes.append(("scalars", scalars))
+
+        repeaters = payload.get("repeaters", {})
+        for section_name, section in repeaters.items():
+            if isinstance(section, list):
+                # list-of-row-dicts shape (PdfF8949)
+                merged: dict[str, str] = {}
+                for row_dict in section:
+                    merged.update(row_dict)
+                scopes.append((section_name, merged))
+            elif isinstance(section, dict):
+                # template+max_slots shape
+                template = section.get("template", {})
+                max_slots = section.get("max_slots", 1)
+                expanded: dict[str, str] = {}
+                for compute_key_tmpl, path_tmpl in template.items():
+                    for i in range(1, max_slots + 1):
+                        expanded[compute_key_tmpl.replace("{i}", str(i))] = (
+                            path_tmpl.replace("{i}", str(i))
+                        )
+                scopes.append((section_name, expanded))
+            else:
+                raise TypeError(
+                    f"{cls.__name__}[{year}] section {section_name!r}: "
+                    f"unexpected type {type(section)}"
+                )
+
+        return scopes
+    else:
+        # Flat dict: treat entire payload as a single scope.
+        return [("scalars", payload)]
+
+
+# ---------------------------------------------------------------------------
+# The invariant test
+# ---------------------------------------------------------------------------
+
+class PdfFieldPathUniquenessTest(unittest.TestCase):
+    """Assert intra-section uniqueness of PDF field paths for every
+    PdfFormMapping subclass and every declared year."""
+
+    def test_no_unallowlisted_duplicate_paths(self) -> None:
+        """For every (class, year) pair, no two compute keys in the same
+        addressable scope may map to the same PDF field path, unless that
+        path is explicitly allowlisted in _KNOWN_SHARED_PATHS for the class.
+
+        Repeater sections are never allowlisted — their uniqueness is absolute.
+        """
+        classes = _discover_pdf_mapping_classes()
+        self.assertGreater(
+            len(classes), 0, "No PdfFormMapping subclasses found — discovery broken"
+        )
+
+        for cls in classes:
+            for year, payload in cls._MAPPINGS.items():
+                with self.subTest(cls=cls.__name__, year=year):
+                    allowed = _KNOWN_SHARED_PATHS.get(cls, frozenset())
+                    scopes = _iter_scopes(cls, year, payload)
+
+                    for scope_name, mapping in scopes:
+                        counts = Counter(mapping.values())
+                        duplicated_paths = {
+                            path for path, cnt in counts.items() if cnt > 1
+                        }
+
+                        if scope_name == "scalars":
+                            # Scalars: allowlisted paths are permitted.
+                            unallowlisted = duplicated_paths - allowed
+                            if unallowlisted:
+                                details = []
+                                for path in sorted(unallowlisted):
+                                    colliding = [
+                                        k for k, v in mapping.items() if v == path
+                                    ]
+                                    details.append(
+                                        f"  path={path!r}  keys={colliding}"
+                                    )
+                                self.fail(
+                                    f"{cls.__name__}[{year}] scalars: "
+                                    f"{len(unallowlisted)} duplicate path(s) not in "
+                                    f"_KNOWN_SHARED_PATHS:\n" + "\n".join(details)
+                                )
+                        else:
+                            # Repeater sections: zero tolerance.
+                            if duplicated_paths:
+                                details = []
+                                for path in sorted(duplicated_paths):
+                                    colliding = [
+                                        k for k, v in mapping.items() if v == path
+                                    ]
+                                    details.append(
+                                        f"  path={path!r}  keys={colliding}"
+                                    )
+                                self.fail(
+                                    f"{cls.__name__}[{year}] repeater section "
+                                    f"{scope_name!r}: {len(duplicated_paths)} "
+                                    f"duplicate path(s) within the section "
+                                    f"(repeater duplicates are never allowlisted):\n"
+                                    + "\n".join(details)
+                                )
+
+    def test_f8949_allowlist_has_exactly_8_entries(self) -> None:
+        """Sanity-check: the PdfF8949 allowlist must contain exactly 8 paths.
+
+        If this fails, the audit in pdf_f8949.py has diverged from the
+        allowlist derivation — reconcile before proceeding.
+        """
+        allowlist = _KNOWN_SHARED_PATHS[PdfF8949]
+        self.assertEqual(
+            len(allowlist),
+            8,
+            f"Expected exactly 8 shared paths for PdfF8949, got {len(allowlist)}: "
+            f"{sorted(allowlist)}",
+        )
+
+    def test_f8949_allowlist_paths_are_totals_only(self) -> None:
+        """Confirm no checkbox paths appear in the PdfF8949 allowlist.
+
+        Checkboxes use per-box array indices (c1_1[0] vs c1_1[1]) and are
+        intentionally distinct — if they appear as duplicates, something
+        changed in the mapping and the architecture assumption broke.
+        """
+        allowlist = _KNOWN_SHARED_PATHS[PdfF8949]
+        checkbox_paths = {p for p in allowlist if "_1[" in p and ".c" in p}
+        self.assertEqual(
+            checkbox_paths,
+            set(),
+            f"Unexpected checkbox path(s) in PdfF8949 allowlist: {checkbox_paths}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pdf_repeater.py
+++ b/tests/test_pdf_repeater.py
@@ -86,6 +86,71 @@ class ExpandRepeatersTests(unittest.TestCase):
         self.assertEqual(expanded, {"a_pdf": "present"})
 
 
+    def test_repeater_numeric_values_are_irs_rounded(self):
+        """Repeater cells with non-integer numeric values must be IRS half-up
+        rounded to whole-dollar strings, matching the scalar fill() path.
+
+        Use 2.5 as the boundary input: irs_round(2.5) → 3 (half-up), but
+        Python's built-in round(2.5) → 2 (banker's). A correct fix renders "3".
+        """
+        mapping = {
+            "scalars": {},
+            "repeaters": {
+                "rows": {
+                    "template": {"amt": "Row{i}.amt[0]"},
+                    "max_slots": 2,
+                    "overflow": "raise",
+                },
+            },
+        }
+        values = {"rows": [{"amt": 2.5}, {"amt": 1234.7}]}
+        expanded = PdfFiller._expand_repeaters(mapping, values)
+        self.assertEqual(expanded["Row1.amt[0]"], "3")     # 2.5 -> 3 (half-up)
+        self.assertEqual(expanded["Row2.amt[0]"], "1235")  # 1234.7 -> 1235
+
+    def test_scalar_in_scalars_dict_is_irs_rounded(self):
+        """Scalar cells in a {scalars, repeaters} payload must also be
+        IRS-rounded, matching the scalar fill() path. (Currently both paths
+        diverge from fill()'s behavior — see _render vs _render_scalar.)
+        """
+        mapping = {
+            "scalars": {"total": "Page1.total[0]"},
+            "repeaters": {},
+        }
+        values = {"total": 99.5}
+        expanded = PdfFiller._expand_repeaters(mapping, values)
+        self.assertEqual(expanded["Page1.total[0]"], "100")  # 99.5 -> 100
+
+    def test_repeater_bool_value_raises(self):
+        """Bool values in a repeater row must raise, matching the scalar
+        fill() path's fail-fast. Bool-valued fields must be routed through
+        a checkbox_states registry, not the scalar/repeater render path.
+        """
+        mapping = {
+            "scalars": {},
+            "repeaters": {
+                "rows": {
+                    "template": {"flag": "Row{i}.flag[0]"},
+                    "max_slots": 2,
+                    "overflow": "raise",
+                },
+            },
+        }
+        values = {"rows": [{"flag": True}]}
+        with self.assertRaises(ValueError):
+            PdfFiller._expand_repeaters(mapping, values)
+
+    def test_scalar_bool_in_scalars_dict_raises(self):
+        """Bool in a scalars dict (under fill_with_repeaters path) must also raise."""
+        mapping = {
+            "scalars": {"flag": "Page1.flag[0]"},
+            "repeaters": {},
+        }
+        values = {"flag": True}
+        with self.assertRaises(ValueError):
+            PdfFiller._expand_repeaters(mapping, values)
+
+
 class FillWithRepeatersTests(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## Summary

Bundled cleanup pass collecting five independent follow-ups surfaced by recent simplification work. Two of the five turned out to be premise-wrong on inspection and are documented below as no-action; the remaining three each land a small, well-tested change.

## Changes

### Drop `datetime.date` alias in `models.py`
Replaces `from datetime import date as _date` with the bare `from datetime import date` import, and updates the four `_date` annotations (`date_placed_in_service`, `disposed`, `date_incorporated`, `s_election_effective_date`) accordingly. The alias added an indirection without paying for itself anywhere — `date` does not collide with anything else in this module.

### Intra-section PDF field-path uniqueness invariant
Adds `tests/test_pdf_field_path_uniqueness.py`, which walks every `PdfFormMapping` subclass (auto-discovered under `tenforty.mappings`) and every declared year, then asserts that within each addressable scope no two compute keys map to the same PDF field path.

"Addressable scope" is the scalars dict (or the entire flat payload, for forms that haven't been split into scalars + repeaters) and each individual repeater section. Cross-section duplicates are intentionally permitted: paginated multi-emission forms like Form 8949 reuse the same per-page table paths across `box_a_rows`/`box_b_rows` (page 1) and `box_d_rows`/`box_e_rows` (page 2) by design — the filler emits a separate physical PDF copy of each page per box.

PdfF8949 has eight intentionally shared *scalar* paths (the four page-level totals on page 1 shared between boxes A/B, plus the same four on page 2 shared between boxes D/E). These are allowlisted via `_KNOWN_SHARED_PATHS`, derived directly from the live source so the constant cannot drift. Two extra sanity tests guard the architectural assumption: the allowlist must contain exactly 8 entries, and no checkbox paths may appear in it (the per-box checkboxes use distinct array indices `c{n}_1[0]` vs `c{n}_1[1]` and must never collide).

Repeater sections are zero-tolerance — never allowlisted — because their uniqueness is what makes row expansion well-defined.

### Reconcile `_render` bool branch with `_render_scalar` fail-fast (and IRS-round repeater cells)
The `_render` static method on `PdfFiller` and the newer `_render_scalar` had drifted apart in two correctness-relevant ways:

1. **Rounding.** `_render_scalar` ran `irs_round` (half-up) before stringifying numerics; `_render` did not. Any non-integer numeric value passed through `fill_with_repeaters` — whether as a scalar in the `scalars` dict or as a cell in a repeater row — was rendered as a raw decimal instead of an IRS-rounded whole-dollar string. The split was invisible until a repeater carried a non-integer total.
2. **Bools.** `_render` rendered `True` as `"Yes"` and `False` as `"Off"`, silently. `_render_scalar` raises, on the principle that bool-valued PDF fields must be routed through a dedicated `checkbox_states` registry, not the scalar/repeater render path. The legacy bool branch was therefore a back door around that policy.

Resolution: deleted `_render` entirely; `_expand_repeaters` now calls `PdfFiller._render_scalar(v)` at both the scalars and repeater-cell sites. Four new tests on `ExpandRepeatersTests` lock in the new behavior — `2.5 → "3"` and `1234.7 → "1235"` for the rounding direction, and bool inputs raise at both the scalar and repeater paths.

The unification surfaced one cascading issue: `forms/sch_a.py` was emitting `"sch_a_line_5a_sales_tax_checkbox": False` into the scalar payload, which `_render` had been silently converting to `"Off"`. With `_render_scalar` now raising on bools, that emission breaks. The value is always-False today (sales-tax election is never set), so the entry is dropped from the compute() return dict, with an inline comment recording the constraint: if a future change ever needs to emit `True` here, the routing must go through a `checkbox_states` registry — and `fill_with_repeaters` does not currently accept one. Architectural extension to add `checkbox_states` to the repeater-aware fill path is tracked separately as #104.

## Investigated, no action

### `pdf_f1120s_k1.py` bool checkbox audit (#51)
Audited the file end-to-end. It declares six flat text fields, no repeaters, and no checkboxes. Nothing in the K-1 mapping is bool-valued, so there is no bypass path to close here. The follow-up was queued speculatively after the broader `/simplify` pass; on inspection, no work to do.

### Extract `_enforce_post_waterfall_gates` helper (#57)
The post-waterfall gate logic in `orchestrator.py:189-193` is a single call: `enforce_compute_time(effective_scenario)`, inside `_build_effective_scenario`. Wrapping a one-line call in a named helper would add indirection without improving readability — the current call site already names the operation via the function it invokes. Closed as no-action.

## Test plan

- [x] T1: `models.py` imports cleanly; no consumers of `_date` outside this file
- [x] T2: `tests/test_pdf_field_path_uniqueness.py` — 3 test methods, 17 subtests, all pass
- [x] T4: `tests/test_pdf_repeater.py` — 4 new test methods covering rounding parity (scalar + repeater) and bool fail-fast (scalar + repeater); existing `EmitPdfsSchATests` continue to pass after dropping the always-False checkbox emission
- [ ] Full suite IV (running)